### PR TITLE
Tag cache entries for easier busting. Bust global report cache on updates

### DIFF
--- a/src/app/GlobalReport.php
+++ b/src/app/GlobalReport.php
@@ -1,6 +1,7 @@
 <?php
 namespace TmlpStats;
 
+use Cache;
 use TmlpStats\StatsReport;
 use Illuminate\Database\Eloquent\Model;
 use Eloquence\Database\Traits\CamelCaseModel;
@@ -34,6 +35,8 @@ class GlobalReport extends Model
             $this->statsReports()->detach($existingReport->id);
         }
         $this->statsReports()->attach($report->id);
+
+        Cache::tags(["globalReport{$this->id}"])->flush();
     }
 
     public function scopeReportingDate($query, Carbon $date)

--- a/src/app/Http/Controllers/CenterStatsController.php
+++ b/src/app/Http/Controllers/CenterStatsController.php
@@ -10,7 +10,6 @@ use TmlpStats\Center;
 use TmlpStats\CenterStatsData;
 use TmlpStats\GlobalReport;
 use TmlpStats\Http\Requests;
-use TmlpStats\Http\Controllers\Controller;
 use TmlpStats\Quarter;
 use TmlpStats\StatsReport;
 
@@ -133,7 +132,7 @@ class CenterStatsController extends Controller
                 }
             }
         }
-        Cache::put($cacheKey, $globalReportData, static::CACHE_TTL);
+        Cache::tags(["globalReport{$id}"])->put($cacheKey, $globalReportData, static::CACHE_TTL);
 
         return $globalReportData;
     }
@@ -179,7 +178,7 @@ class CenterStatsController extends Controller
                 $week->addWeek();
             }
         }
-        Cache::put($cacheKey, $centerStatsData, static::CACHE_TTL);
+        Cache::tags(["statsReport{$id}"])->put($cacheKey, $centerStatsData, static::STATS_REPORT_CACHE_TTL);
 
         return $centerStatsData;
     }

--- a/src/app/Http/Controllers/Controller.php
+++ b/src/app/Http/Controllers/Controller.php
@@ -10,4 +10,5 @@ abstract class Controller extends BaseController {
     use DispatchesCommands, ValidatesRequests;
 
     const CACHE_TTL = 60;
+    const STATS_REPORT_CACHE_TTL = 2 * 24 * 60;
 }

--- a/src/app/Http/Controllers/CoursesController.php
+++ b/src/app/Http/Controllers/CoursesController.php
@@ -96,8 +96,6 @@ class CoursesController extends Controller
         if (!$courses) {
             $statsReport = StatsReport::find($id);
 
-            $this->statsReport = $statsReport;
-
             if (!$statsReport) {
                 return null;
             }
@@ -131,7 +129,7 @@ class CoursesController extends Controller
 
             $courses['completedThisWeek'] = $completedCourses;
         }
-        Cache::put($cacheKey, $courses, static::CACHE_TTL);
+        Cache::tags(["statsReport{$id}"])->put($cacheKey, $courses, static::STATS_REPORT_CACHE_TTL);
 
         return $courses;
     }

--- a/src/app/Http/Controllers/GlobalReportController.php
+++ b/src/app/Http/Controllers/GlobalReportController.php
@@ -1,6 +1,7 @@
 <?php namespace TmlpStats\Http\Controllers;
 
 use App;
+use Response;
 use TmlpStats\Http\Requests;
 use TmlpStats\GlobalReport;
 use TmlpStats\StatsReport;
@@ -93,6 +94,10 @@ class GlobalReportController extends Controller
         }
 
         $globalReport = GlobalReport::find($id);
+        if (!$globalReport) {
+            $error = 'Report not found.';
+            return  Response::view('errors.404', compact('error'), 404);
+        }
 
         $centers = $this->getStatsReportsNotOnList($globalReport);
         if ($centers) {
@@ -235,6 +240,11 @@ class GlobalReportController extends Controller
         }
 
         $globalReport = GlobalReport::find($id);
+        if (!$globalReport) {
+            $error = 'Report not found.';
+            return  Response::view('errors.404', compact('error'), 404);
+        }
+
         $statsReports = $globalReport->statsReports()->get();
 
         $totalPoints = 0;

--- a/src/app/Http/Controllers/TeamMembersController.php
+++ b/src/app/Http/Controllers/TeamMembersController.php
@@ -95,8 +95,6 @@ class TeamMembersController extends Controller
         if (!$teamMembers) {
             $statsReport = StatsReport::find($id);
 
-            $this->statsReport = $statsReport;
-
             if (!$statsReport) {
                 return null;
             }
@@ -195,7 +193,7 @@ class TeamMembersController extends Controller
             $teamMembers['gitw'] = $gitw;
             $teamMembers['withdraws'] = $withdraws;
         }
-        Cache::put($cacheKey, $teamMembers, static::CACHE_TTL);
+        Cache::tags(["statsReport{$id}"])->put($cacheKey, $teamMembers, static::STATS_REPORT_CACHE_TTL);
 
         return $teamMembers;
     }

--- a/src/app/Http/Controllers/TmlpRegistrationsController.php
+++ b/src/app/Http/Controllers/TmlpRegistrationsController.php
@@ -95,8 +95,6 @@ class TmlpRegistrationsController extends Controller
         if (!$tmlpRegistrations) {
             $statsReport = StatsReport::find($id);
 
-            $this->statsReport = $statsReport;
-
             if (!$statsReport) {
                 return null;
             }
@@ -212,7 +210,7 @@ class TmlpRegistrationsController extends Controller
             $tmlpRegistrations['applications'] = $applications;
             $tmlpRegistrations['withdraws'] = $withdraws;
         }
-        Cache::put($cacheKey, $tmlpRegistrations, static::CACHE_TTL);
+        Cache::tags(["statsReport{$id}"])->put($cacheKey, $tmlpRegistrations, static::STATS_REPORT_CACHE_TTL);
 
         return $tmlpRegistrations;
     }

--- a/src/resources/views/errors/404.blade.php
+++ b/src/resources/views/errors/404.blade.php
@@ -1,0 +1,33 @@
+@extends('template')
+
+@section('headers')
+<style>
+    .error-template {
+        padding: 40px 15px;text-align: center;
+    }
+    .error-actions {
+        margin-top:15px;margin-bottom:15px;
+    }
+    .error-actions .btn {
+        margin-right:10px;
+    }
+</style>
+@endsection
+
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="error-template">
+            <h1>Oops!</h1>
+            <h2>404 Not Found</h2>
+            <div class="error-details">
+                Sorry, an error has occurred, and the page you were looking for was not found!
+            </div>
+            <div class="error-actions">
+                <a href="{{ url('/') }}" class="btn btn-primary btn-lg"><span class="glyphicon glyphicon-home"></span> Take Me Home</a>
+                {{--<a href="http://www.jquery2dotnet.com" class="btn btn-default btn-lg"><span class="glyphicon glyphicon-envelope"></span> Contact Support </a>--}}
+            </div>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
- Add cache tags for objects cached by statsReport, and globalReport. 
- Increase the cache TTL for statsreport cached items since reports never change after they are submitted
- Bust global report cache when new entries are added.
- Do some minor cleanup