### PR TITLE
Allow variable length course lists

### DIFF
--- a/src/app/Import/Xlsx/DataImporter/CommCourseInfoImporter.php
+++ b/src/app/Import/Xlsx/DataImporter/CommCourseInfoImporter.php
@@ -17,11 +17,13 @@ class CommCourseInfoImporter extends DataImporterAbstract
 
     protected function populateSheetRanges()
     {
+        $cap = $this->findRange(3, 'Course Start Date', 'Total (Open Courses):', 'B', 'A');
         $this->blockCAP[] = $this->excelRange('A','O');
-        $this->blockCAP[] = $this->excelRange(5,14);
+        $this->blockCAP[] = $this->excelRange($cap['start'] + 1, $cap['end']);
 
+        $cpc = $this->findRange($cap['end'], 'Course Start Date', 'Total (Open Courses):', 'B', 'A');
         $this->blockCPC[] = $this->excelRange('A','O');
-        $this->blockCPC[] = $this->excelRange(18,25);
+        $this->blockCPC[] = $this->excelRange($cpc['start'] + 1, $cpc['end']);
     }
 
     protected function load()

--- a/src/app/Import/Xlsx/DataImporter/DataImporterAbstract.php
+++ b/src/app/Import/Xlsx/DataImporter/DataImporterAbstract.php
@@ -57,20 +57,36 @@ abstract class DataImporterAbstract
     // This lets us process each block separately
     abstract protected function populateSheetRanges();
 
-    protected function findRange($startRow, $targetStartText, $targetEndText, $targetColumn = 'A')
+    /**
+     * @param $startRow                 Index of the row to start searching in
+     * @param $targetStartText          Cell text that indicates the start of the range
+     * @param $targetEndText            Cell text that indicates the end of the range
+     * @param string $targetStartColumn Column to look in for the targetStartText
+     * @param null $targetEndColumn     Column to look in for the targetEndText
+     * @return array[start, end]        Array with the start and end of the range, inclusive
+     *                                  start is the index immediately after the row with targetStartText
+     *                                  end is the index immediately before the row with targetEndText
+     */
+    protected function findRange($startRow, $targetStartText, $targetEndText, $targetStartColumn = 'A', $targetEndColumn = null)
     {
         $rangeStart = NULL;
         $rangeEnd = NULL;
+
+        if ($targetEndColumn === null) {
+            $targetEndColumn = $targetStartColumn;
+        }
 
         $row = $startRow;
         $searching = true;
         $maxRows = count($this->sheet);
         $maxSearchRows = 500;
+        $targetColumn = $targetStartColumn;
         while ($searching && $row < $maxSearchRows) {
             $value = $this->sheet[$row][$targetColumn];
 
             if ($rangeStart === NULL && $value == $targetStartText) {
                 $rangeStart = $row + 1; // Range starts the row after start text
+                $targetColumn = $targetEndColumn;
             }
 
             if ($rangeEnd === NULL && ($value == $targetEndText || $row >= $maxRows)) {

--- a/src/app/Message.php
+++ b/src/app/Message.php
@@ -346,7 +346,7 @@ class Message
             ),
         ),
         'COMMCOURSE_COMPLETED_SS_GREATER_THAN_CURRENT_SS' => array(
-            'type' => Message::WARNING,
+            'type' => Message::ERROR,
             'format' => "More people completed the course than there were that started. Make sure Current Standard Starts matches the number of people that started the course, and Completed Standard Starts matches the number of people that completed the course.",
             'arguments' => array(),
         ),


### PR DESCRIPTION
Issue #151 

Allow course variable length course lists in the communication course import. I used the same method we use for the class list and tmlp registration sections.

Fixed display for an error that was showing up as a warning.