### PR TITLE
Show partial quarter TDO & GITW data

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -535,7 +535,7 @@ class StatsReportController extends Controller
         while ($date->lte($statsReport->reportingDate)) {
             $globalReport = GlobalReport::reportingDate($date)->first();
             $report = $globalReport->statsReports()->byCenter($statsReport->center)->first();
-            $weeksData[$date->toDateString()] = App::make(TeamMembersController::class)->getByStatsReport($report->id);
+            $weeksData[$date->toDateString()] = $report ? App::make(TeamMembersController::class)->getByStatsReport($report->id) : null;
             $date->addWeek();
         }
         if (!$weeksData) {
@@ -557,7 +557,7 @@ class StatsReportController extends Controller
         while ($date->lte($statsReport->reportingDate)) {
             $globalReport = GlobalReport::reportingDate($date)->first();
             $report = $globalReport->statsReports()->byCenter($statsReport->center)->first();
-            $weeksData[$date->toDateString()] = App::make(TeamMembersController::class)->getByStatsReport($report->id);
+            $weeksData[$date->toDateString()] = $report ? App::make(TeamMembersController::class)->getByStatsReport($report->id) : null;
             $date->addWeek();
         }
         if (!$weeksData) {

--- a/src/app/Reports/Arrangements/TeamMemberWeeklyValue.php
+++ b/src/app/Reports/Arrangements/TeamMemberWeeklyValue.php
@@ -16,6 +16,12 @@ abstract class TeamMemberWeeklyValue extends BaseArrangement
         ];
         foreach ($teamMembersData as $date => $teamData) {
             $dates[] = Carbon::createFromFormat('Y-m-d', $date);
+
+            // Weeks can be empty if we don't have any data from that week.
+            if (!$teamData) {
+                continue;
+            }
+
             foreach ($teamData as $data) {
 
                 $teamYear = ($data->teamMember->teamYear == 1)

--- a/src/resources/views/statsreports/details/teammembersweekly.blade.php
+++ b/src/resources/views/statsreports/details/teammembersweekly.blade.php
@@ -19,7 +19,7 @@
                     @foreach ($reportData['dates'] as $date)
                         <?php $data = isset($memberRow[$date->toDateString()]) ? $memberRow[$date->toDateString()] : null; ?>
                         @if ($data === null)
-                            <td class="active" style="color: #006000; text-align: center">
+                            <td class="active" style="color: #666666; text-align: center">
                                 <span class="glyphicon glyphicon-minus"></span>
                             </td>
                         @elseif ($data['value'])


### PR DESCRIPTION
When a team starts submitting sheets part way through the quarter, they don't have
TDO and GITW data from previous weeks. Handle this nicely.