### PR TITLE
Handle centerstats data issues gracefully

### DIFF
--- a/src/app/Http/Controllers/CenterStatsController.php
+++ b/src/app/Http/Controllers/CenterStatsController.php
@@ -258,9 +258,19 @@ class CenterStatsController extends Controller
             $statsReport = $globalReport->statsReports()->byCenter($center)->first();
         }
 
+        $actual = null;
+        if ($statsReport) {
+            $actual = CenterStatsData::actual()
+                ->reportingDate($date)
+                ->byStatsReport($statsReport)
+                ->first();
+        }
+
         // If not, search from the beginning until we find it
-        if (!$statsReport) {
+        if (!$actual) {
             $statsReport = $this->findFirstWeek($center, $quarter, 'actual');
+        } else {
+            return $actual;
         }
 
         if (!$statsReport) {

--- a/src/app/Reports/Arrangements/GamesByWeek.php
+++ b/src/app/Reports/Arrangements/GamesByWeek.php
@@ -14,6 +14,9 @@ class GamesByWeek extends BaseArrangement
         $reportData = [];
         foreach ($centerStatsData as $data) {
 
+            if (!$data) {
+                continue;
+            }
             $type = $data->type;
             $dateString = $data->reportingDate->toDateString();
             $reportData[$dateString][$type] = [];


### PR DESCRIPTION
If a center has submitted a report before, but it wasn't valid, the centerstats
report was barfing trying to find the right actual data. Handle this case
gracefully.