### PR TITLE
Lockdown report token users

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -363,6 +363,7 @@ class StatsReportController extends Controller
                 $response =  $this->getCourses($statsReport);
                 break;
             case 'contactinfo':
+                $this->authorize('readContactInfo', $statsReport);
                 $response =  $this->getContacts($statsReport);
                 break;
             case 'gitwsummary':

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -78,13 +78,6 @@ Route::post('home/clientsettings', function () {
     }
 });
 
-Route::get('auth/reauth', function() {
-    // Logout and show login page (used to upgrade a report user)
-    Auth::logout();
-
-    return redirect('auth/login');
-});
-
 Route::controllers([
     'auth' => 'Auth\AuthController',
     'password' => 'Auth\PasswordController',

--- a/src/app/Policies/StatsReportPolicy.php
+++ b/src/app/Policies/StatsReportPolicy.php
@@ -31,7 +31,7 @@ class StatsReportPolicy extends Policy
         } else if ($user->hasRole('localStatistician')) {
             return $user->center->id === $statsReport->center->id || $user->id === $statsReport->user->id;
         } else if ($user->hasRole('readonly')) {
-            $result = !$user->center || $user->center->id === $statsReport->center->id;
+            $result = $user->center && $user->center->id === $statsReport->center->id;
             return $result;
         }
 
@@ -109,5 +109,10 @@ class StatsReportPolicy extends Policy
     public function validate(User $user)
     {
         return $user->hasRole('globalStatistician') || $user->hasRole('localStatistician');
+    }
+
+    public function readContactInfo(User $user, StatsReport $statsReport)
+    {
+        return $this->read($user, $statsReport) && !$user->hasRole('readonly');
     }
 }

--- a/src/resources/views/partials/navbar.blade.php
+++ b/src/resources/views/partials/navbar.blade.php
@@ -41,7 +41,7 @@
             </ul>
 
             <ul class="nav navbar-nav navbar-right">
-                @if (Auth::guest() || (Auth::user()->hasRole('readonly') && Request::is('home')))
+                @if (Auth::guest() || Auth::user()->hasRole('readonly')))
                     <li {!! Request::is('/') ? 'class="active"' : '' !!}>
                         <a href="{{ url('/auth/login') }}">Login/Register</a>
                     </li>
@@ -49,11 +49,7 @@
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">{{ Auth::user()->firstName }} <span class="caret"></span></a>
                         <ul class="dropdown-menu" role="menu">
-                            @if (Auth::user()->hasRole('readonly'))
-                                <li><a href="{{ url('/auth/reauth') }}">Login</a></li>
-                            @else
-                                <li><a href="{{ url('/auth/logout') }}">Logout</a></li>
-                            @endif
+                            <li><a href="{{ url('/auth/logout') }}">Logout</a></li>
                         </ul>
                     </li>
                 @endif

--- a/src/resources/views/statsreports/show.blade.php
+++ b/src/resources/views/statsreports/show.blade.php
@@ -49,7 +49,9 @@
             <li><a href="#classlist-tab" data-toggle="tab">Team Members</a></li>
             <li><a href="#tmlpregistrations-tab" data-toggle="tab">Team Expansion</a></li>
             <li><a href="#courses-tab" data-toggle="tab">Courses</a></li>
+            @can ('readContactInfo', $statsReport)
             <li><a href="#contactinfo-tab" data-toggle="tab">Contact Info</a></li>
+            @endcan
         </ul>
 
         <div class="tab-content">
@@ -109,12 +111,14 @@
                     @include('partials.loading')
                 </div>
             </div>
+            @can ('readContactInfo', $statsReport)
             <div class="tab-pane" id="contactinfo-tab">
                 <h3>Contact Info</h3>
                 <div id="contactinfo-container">
                     @include('partials.loading')
                 </div>
             </div>
+            @endcan
         </div>
     </div>
 
@@ -316,6 +320,7 @@
                 }
             });
 
+            @can ('readContactInfo', $statsReport)
             // Fetch Contact Info
             $.ajax({
                 type: "GET",
@@ -328,6 +333,7 @@
                     $("#contactinfo-container").html('<p>' + message + '</p>');
                 }
             });
+            @endcan
         });
     </script>
 


### PR DESCRIPTION
- ReportTokens with no center specified can longer view all center reports
- Show login link all the time when authenticated as readonly to make it more obvious