### PR TITLE
Fix validation of London courses

### DIFF
--- a/src/app/Import/Xlsx/DataImporter/TmlpGameInfoImporter.php
+++ b/src/app/Import/Xlsx/DataImporter/TmlpGameInfoImporter.php
@@ -20,11 +20,13 @@ class TmlpGameInfoImporter extends DataImporterAbstract
 
     protected function populateSheetRanges()
     {
+        $t1x = $this->findRange(30, 'Game', 'Total', 'B', 'A');
         $this->blockT1X[] = $this->excelRange('A', 'K');
-        $this->blockT1X[] = $this->excelRange(30, 31);
+        $this->blockT1X[] = $this->excelRange($t1x['start'] + 1, $t1x['end']);
 
+        $t2x = $this->findRange($t1x['end'] + 1, 'Game', 'Total', 'B', 'A');
         $this->blockT2X[] = $this->excelRange('A', 'K');
-        $this->blockT2X[] = $this->excelRange(38, 39);
+        $this->blockT2X[] = $this->excelRange($t2x['start'] + 1, $t2x['end']);
     }
 
     protected function load()

--- a/src/app/Validate/CommCourseInfoValidator.php
+++ b/src/app/Validate/CommCourseInfoValidator.php
@@ -69,8 +69,14 @@ class CommCourseInfoValidator extends ValidatorAbstract
             if (!is_null($data->completedStandardStarts) && !is_null($data->currentStandardStarts)) {
                 if ($data->completedStandardStarts > $data->currentStandardStarts) {
 
-                    $this->addMessage('COMMCOURSE_COMPLETED_SS_GREATER_THAN_CURRENT_SS');
-                    $isValid = false;
+                    $location = strtolower($data->location);
+
+                    if ($statsReport->center->name == 'London' && ($location == 'germany' || $location == 'intl')) {
+                        // Special case handling for courses in London where the standard starts count is different
+                    } else {
+                        $this->addMessage('COMMCOURSE_COMPLETED_SS_GREATER_THAN_CURRENT_SS');
+                        $isValid = false;
+                    }
                 } else if ($data->completedStandardStarts < ($data->currentStandardStarts - 3) && $startDate->diffInDays($statsReport->reportingDate) < 7) {
 
                     $withdrew = $data->currentStandardStarts - $data->completedStandardStarts;

--- a/src/app/Validate/ContactInfoValidator.php
+++ b/src/app/Validate/ContactInfoValidator.php
@@ -25,11 +25,8 @@ class ContactInfoValidator extends ValidatorAbstract
         $emailValidator = v::email();
         if ($data->accountability == 'Reporting Statistician') {
             $emailValidator = v::alwaysValid();
-        }
-
-        // Skip rows with names == NA or N/A
-        if (preg_match('/^N\/?A$/i', $data->name)) {
-            return;
+        } else if (preg_match('/^N\/?A$/i', $data->name)) {
+            return; // Skip rows with names == NA or N/A
         }
 
         $this->dataValidators['name']           = v::string()->regex('/^(.+)\s([^\s]+)$/i');

--- a/src/tests/unit/Validate/ContactInfoValidatorTest.php
+++ b/src/tests/unit/Validate/ContactInfoValidatorTest.php
@@ -20,8 +20,24 @@ class ContactInfoValidatorTest extends ValidatorTestAbstract
     {
         $data = new stdClass;
         $data->accountability = 'Program Manager';
+        $data->name = 'Jeff Bridges';
 
         parent::testPopulateValidatorsSetsValidatorsForEachInput($data);
+    }
+
+    public function testPopulateValidatorsSkipsNameWhenNotApplicable($data = null)
+    {
+        $data = new stdClass;
+        $data->accountability = 'Program Manager';
+        $data->name = 'N/A';
+
+        // When name is N/A, we skip all validation
+        $tmpDataFields = $this->dataFields;
+        $this->dataFields = [];
+
+        parent::testPopulateValidatorsSetsValidatorsForEachInput($data);
+
+        $this->dataFields = $tmpDataFields;
     }
 
     public function testPopulateValidatorsSetsValidatorsForEachInputReportingStatistician($data = null)

--- a/src/tests/unit/Validate/ValidatorTestAbstract.php
+++ b/src/tests/unit/Validate/ValidatorTestAbstract.php
@@ -5,6 +5,8 @@ use stdClass;
 
 class ValidatorTestAbstract extends \TmlpStats\Tests\TestAbstract
 {
+    protected $dataFields = [];
+
     //
     // populateValidators()
     //


### PR DESCRIPTION
Some courses out of the London center (Germany and INTL) are tracked differently than
in other centers. Instead of counting all registrations, they only count the registrations
generated by team. This makes the course completion stats checks inaccurate.

- Added a special case check for London courses in Germany and INTL and don't throw the completion stats error
- Added new test cases
- Updated test cases from previous updates