### PR TITLE
Add mysql memory tuning cnf by default with anisible

### DIFF
--- a/ansible/aws.playbook.yml
+++ b/ansible/aws.playbook.yml
@@ -142,22 +142,10 @@
   - file: path=/etc/mysql/conf.d state=directory
 
   # Custom MySQL Config settings (low memory footprint for AWS)
-  - lineinfile: dest=/etc/mysql/my.cnf regexp='^key_buffer\s*=' line='key_buffer = 8M' state=present
-    notify: restart mysql
+  - file: path=/etc/mysql/conf.d/ state=directory owner=root
 
-  - lineinfile: dest=/etc/mysql/my.cnf regexp='^max_connections\s*=' line='max_connections = 30' state=present
-    notify: restart mysql
-
-  - lineinfile: dest=/etc/mysql/my.cnf regexp='^query_cache_size\s*=' line='query_cache_size = 8M' state=present
-    notify: restart mysql
-
-  - lineinfile: dest=/etc/mysql/my.cnf regexp='^query_cache_limit\s*=' line='query_cache_limit = 512K' state=present
-    notify: restart mysql
-
-  - lineinfile: dest=/etc/mysql/my.cnf regexp='^thread_stack\s*=' line='thread_stack = 128K' state=present
-    notify: restart mysql
-
-  - lineinfile: dest=/etc/mysql/my.cnf regexp='^performance_schema\s*=' line='performance_schema = 0' state=present
+  - name: add mysql config
+    copy: src=/vagrant/ansible/templates/etc/mysql/conf.d/memory_tuned.cnf dest=/etc/mysql/conf.d/memory_tuned.cnf
     notify: restart mysql
 
   # PHP 5.6

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -82,6 +82,12 @@
     with_items:
       - "{{ db_main }}"
 
+  - file: path=/etc/mysql/conf.d/ state=directory owner=root
+
+  - name: add mysql config
+    copy: src=/vagrant/ansible/templates/etc/mysql/conf.d/memory_tuned.cnf dest=/etc/mysql/conf.d/memory_tuned.cnf
+    notify: restart mysql
+
   # PHP: Setup PHP 5.6
 
   - name: add php5.6 ppa
@@ -108,10 +114,13 @@
   - copy: src=/vagrant/ansible/templates/etc/php5/mods-available/xdebug.ini dest=/etc/php5/mods-available/xdebug.ini
     notify: restart apache
 
-  # Puppet - Not Installed
+  # Puppet & Chef - Not Installed
 
   - name: ensure puppet is not installed
     apt: name=puppet state=absent
+
+  - name: ensure chef is not installed
+    apt: name=chef state=absent
 
   # Finalize
 

--- a/ansible/templates/etc/mysql/conf.d/memory_tuned.cnf
+++ b/ansible/templates/etc/mysql/conf.d/memory_tuned.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+key_buffer         = 8M
+max_connections    = 20
+query_cache_size   = 8M
+query_cache_limit  = 512K
+thread_stack       = 128K
+performance_schema = 0

--- a/ansible/templates/etc/mysql/conf.d/my.cnf
+++ b/ansible/templates/etc/mysql/conf.d/my.cnf
@@ -1,2 +1,0 @@
-[mysqld]
-max_connections = 20


### PR DESCRIPTION
The biggest reason is to make sure performance_schema is off. it uses a lot of
memory and that bogs down the VM when running with 1GB memory.

While we're in there, make sure chef isn't installed.