### PR TITLE
Cache Model Relationships

### DIFF
--- a/src/app/Accountability.php
+++ b/src/app/Accountability.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class Accountability extends Model
+class Accountability extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         'name',
         'context',

--- a/src/app/Center.php
+++ b/src/app/Center.php
@@ -2,13 +2,9 @@
 namespace TmlpStats;
 
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
 
-class Center extends Model
+class Center extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         'name',
         'abbreviation',

--- a/src/app/CenterStatsData.php
+++ b/src/app/CenterStatsData.php
@@ -3,13 +3,9 @@ namespace TmlpStats;
 
 use TmlpStats\Center;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
 
-class CenterStatsData extends Model
+class CenterStatsData extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $table = 'center_stats_data';
 
     protected $center = null;

--- a/src/app/Course.php
+++ b/src/app/Course.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class Course extends Model
+class Course extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = [
         'center_id',
         'start_date',

--- a/src/app/CourseData.php
+++ b/src/app/CourseData.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class CourseData extends Model
+class CourseData extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $table = 'courses_data';
 
     protected $fillable = [

--- a/src/app/GlobalReport.php
+++ b/src/app/GlobalReport.php
@@ -1,18 +1,14 @@
 <?php
 namespace TmlpStats;
 
-use Cache;
 use TmlpStats\StatsReport;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-use Carbon\Carbon;
 use TmlpStats\Quarter;
 
-class GlobalReport extends Model
-{
-    use CamelCaseModel;
+use Carbon\Carbon;
+use Cache;
 
+class GlobalReport extends ModelCachedRelationships
+{
     protected $fillable = [
         'reporting_date',
         'quarter_id',

--- a/src/app/ModelCache.php
+++ b/src/app/ModelCache.php
@@ -1,0 +1,24 @@
+<?php
+namespace TmlpStats;
+
+class ModelCache
+{
+    protected static $modelCache = [];
+
+    public static function create()
+    {
+        return new static();
+    }
+
+    public function get($key, $id)
+    {
+        return isset(static::$modelCache[$key][$id])
+            ? static::$modelCache[$key][$id]
+            : null;
+    }
+
+    public function set($key, $id, $value)
+    {
+        static::$modelCache[$key][$id] = $value;
+    }
+}

--- a/src/app/ModelCachedRelationships.php
+++ b/src/app/ModelCachedRelationships.php
@@ -1,0 +1,29 @@
+<?php
+namespace TmlpStats;
+
+use Illuminate\Database\Eloquent\Model;
+use Eloquence\Database\Traits\CamelCaseModel;
+
+class ModelCachedRelationships extends Model
+{
+    use CamelCaseModel;
+
+    public function getRelationshipFromMethod($method)
+    {
+        $relations = $this->$method();
+        $relationKey = $relations->getForeignKey();
+
+        $id = $this->$relationKey;
+        if ($id === null) {
+            return parent::getRelationshipFromMethod($method);
+        }
+
+        $cachedValue = ModelCache::create()->get($method, $id);
+        if ($cachedValue === null) {
+            $cachedValue = parent::getRelationshipFromMethod($method);
+            ModelCache::create()->set($method, $id, $cachedValue);
+        }
+
+        return $cachedValue;
+    }
+}

--- a/src/app/Person.php
+++ b/src/app/Person.php
@@ -3,13 +3,9 @@ namespace TmlpStats;
 
 use DB;
 use TmlpStats\Center;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
 
-class Person extends Model
+class Person extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = [
         'first_name',
         'last_name',

--- a/src/app/Quarter.php
+++ b/src/app/Quarter.php
@@ -2,19 +2,12 @@
 namespace TmlpStats;
 
 use Cache;
-use TmlpStats\Region;
-use TmlpStats\RegionQuarterDetails;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
 use Carbon\Carbon;
 
-use DB;
 use Exception;
 
-class Quarter extends Model
+class Quarter extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         't1_distinction',
         't2_distinction',

--- a/src/app/Region.php
+++ b/src/app/Region.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class Region extends Model
+class Region extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         'abbreviation',
         'name',

--- a/src/app/RegionQuarterDetails.php
+++ b/src/app/RegionQuarterDetails.php
@@ -3,17 +3,10 @@ namespace TmlpStats;
 
 use TmlpStats\Quarter;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
 use Carbon\Carbon;
 
-use DB;
-use Exception;
-
-class RegionQuarterDetails extends Model
+class RegionQuarterDetails extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         'quarter_id',
         'region_id',

--- a/src/app/ReportToken.php
+++ b/src/app/ReportToken.php
@@ -3,15 +3,12 @@
 namespace TmlpStats;
 
 use Carbon\Carbon;
-use Eloquence\Database\Traits\CamelCaseModel;
 use Illuminate\Database\Eloquent\Model;
 
 use Exception;
 
-class ReportToken extends Model
+class ReportToken extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         'token',
         'report_id',

--- a/src/app/Role.php
+++ b/src/app/Role.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class Role extends Model
+class Role extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         'name',
         'display',

--- a/src/app/Setting.php
+++ b/src/app/Setting.php
@@ -2,13 +2,8 @@
 
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class Setting extends Model
+class Setting extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = [
         'center_id',
         'name',

--- a/src/app/StatsReport.php
+++ b/src/app/StatsReport.php
@@ -3,15 +3,11 @@ namespace TmlpStats;
 
 use TmlpStats\Quarter;
 use TmlpStats\CenterStatsData;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
 
 use Carbon\Carbon;
 
-class StatsReport extends Model
+class StatsReport extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = [
         'reporting_date',
         'center_id',

--- a/src/app/TeamMember.php
+++ b/src/app/TeamMember.php
@@ -2,14 +2,9 @@
 namespace TmlpStats;
 
 use TmlpStats\Quarter;
-use TmlpStats\Person;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
 
-class TeamMember extends Model
+class TeamMember extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = [
         'person_id',
         'team_year',

--- a/src/app/TeamMemberData.php
+++ b/src/app/TeamMemberData.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class TeamMemberData extends Model
+class TeamMemberData extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $table = 'team_members_data';
 
     protected $fillable = [

--- a/src/app/TmlpGameData.php
+++ b/src/app/TmlpGameData.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class TmlpGameData extends Model
+class TmlpGameData extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $table = 'tmlp_games_data';
 
     protected $fillable = [

--- a/src/app/TmlpRegistration.php
+++ b/src/app/TmlpRegistration.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class TmlpRegistration extends Model
+class TmlpRegistration extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = [
         'person_id',
         'team_year',

--- a/src/app/TmlpRegistrationData.php
+++ b/src/app/TmlpRegistrationData.php
@@ -1,14 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class TmlpRegistrationData extends Model
+class TmlpRegistrationData extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $table = 'tmlp_registrations_data';
 
     protected $fillable = [

--- a/src/app/User.php
+++ b/src/app/User.php
@@ -2,15 +2,13 @@
 namespace TmlpStats;
 
 use Illuminate\Auth\Authenticatable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
-use Eloquence\Database\Traits\CamelCaseModel;
 
-class User extends Model implements AuthenticatableContract, CanResetPasswordContract
+class User extends ModelCachedRelationships implements AuthenticatableContract, CanResetPasswordContract
 {
-    use Authenticatable, CanResetPassword, CamelCaseModel;
+    use Authenticatable, CanResetPassword;
 
     /**
      * The database table used by the model.

--- a/src/app/WithdrawCode.php
+++ b/src/app/WithdrawCode.php
@@ -1,13 +1,8 @@
 <?php
 namespace TmlpStats;
 
-use Illuminate\Database\Eloquent\Model;
-use Eloquence\Database\Traits\CamelCaseModel;
-
-class WithdrawCode extends Model
+class WithdrawCode extends ModelCachedRelationships
 {
-    use CamelCaseModel;
-
     protected $fillable = array(
         'code',
         'display',


### PR DESCRIPTION
Reviewing trace data in newrelic revealed that models are refetched each time
a new model references a relationship. That means if there are 35 team members
and we use the center they belong to for each, the center is queried from the db
35 times.

This change addes a layer to cache the object based on type and id.