### PR TITLE
Lock stats reports when they are submitted

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -266,6 +266,7 @@ class StatsReportController extends Controller
 
             $statsReport->submittedAt = Carbon::now();
             $statsReport->submitComment = Input::get('comment', null);
+            $statsReport->locked = true;
 
             if ($statsReport->save()) {
                 // Cache the validation results so we don't have to regenerate


### PR DESCRIPTION
After they are submitted, they should never be changed anyway. However, when
validate is run, it updates the valdated result and subsequently the updated_at
timestamp unless the sheet is locked.

This change will prevent any modifications after it is submitted