### PR TITLE
Fix bug in laravel relationship fetch and more model caching enhancements

### DIFF
--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -7,7 +7,6 @@ use TmlpStats\CenterStatsData;
 use TmlpStats\CourseData;
 use TmlpStats\GlobalReport;
 use TmlpStats\Quarter;
-use TmlpStats\Reports\Diffs\TmlpRegistrationDiff;
 use TmlpStats\ReportToken;
 use TmlpStats\StatsReport;
 

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -7,10 +7,9 @@ use TmlpStats\CenterStatsData;
 use TmlpStats\CourseData;
 use TmlpStats\GlobalReport;
 use TmlpStats\Quarter;
+use TmlpStats\Reports\Diffs\TmlpRegistrationDiff;
 use TmlpStats\ReportToken;
 use TmlpStats\StatsReport;
-use TmlpStats\TeamMemberData;
-use TmlpStats\TmlpRegistrationData;
 
 use TmlpStats\Import\ImportManager;
 use TmlpStats\Import\Xlsx\XlsxImporter;

--- a/src/app/ModelCachedRelationships.php
+++ b/src/app/ModelCachedRelationships.php
@@ -10,6 +10,12 @@ class ModelCachedRelationships extends Model
 
     public function getRelationshipFromMethod($method)
     {
+        // I think this is a bug in Laravel's Eloquent Model where if they model is copied,
+        // we don't bother checking if the relation was eager loaded so we get 2 lookups
+        if (isset($this->relations[$method])) {
+            return $this->relations[$method];
+        }
+
         $relations = $this->$method();
         $relationKey = $relations->getForeignKey();
 
@@ -18,9 +24,22 @@ class ModelCachedRelationships extends Model
             return parent::getRelationshipFromMethod($method);
         }
 
+        return static::getFromCache($method, $id, function() use ($method) {
+            return parent::getRelationshipFromMethod($method);
+        });
+    }
+
+    public static function getFromCache($method, $id, $default = null)
+    {
         $cachedValue = ModelCache::create()->get($method, $id);
         if ($cachedValue === null) {
-            $cachedValue = parent::getRelationshipFromMethod($method);
+
+            if (is_callable($default)) {
+                $cachedValue = $default();
+            } else {
+                $cachedValue = $default;
+            }
+
             ModelCache::create()->set($method, $id, $cachedValue);
         }
 

--- a/src/app/Quarter.php
+++ b/src/app/Quarter.php
@@ -47,25 +47,20 @@ class Quarter extends ModelCachedRelationships
     public static function findForCenter($id, Center $center)
     {
         $key = "quarter:region{$center->regionId}";
-        $quarter = ModelCache::create()->get($key, $id);
-        if ($quarter === null) {
+        return static::getFromCache($key, $id, function() use ($id, $center) {
             $quarter = Quarter::find($id);
             if ($quarter) {
                 $quarter->setRegion($center->region);
             }
-
-            ModelCache::create()->set($key, $id, $quarter);
-        }
-
-        return $quarter;
+            return $quarter;
+        });
     }
 
     public static function getQuarterByDate(Carbon $date, Region $region)
     {
         $dateString = $date->toDateString();
         $key = "quarters:region{$region->id}:dates";
-        $quarter = ModelCache::create()->get($key, $dateString);
-        if ($quarter === null) {
+        return static::getFromCache($key, $dateString, function() use ($date, $region) {
             $quarter = Quarter::byRegion($region)
                 ->date($date)
                 ->first();
@@ -73,11 +68,8 @@ class Quarter extends ModelCachedRelationships
             if ($quarter) {
                 $quarter->setRegion($region);
             }
-
-            ModelCache::create()->set($key, $dateString, $quarter);
-        }
-
-        return $quarter;
+            return $quarter;
+        });
     }
 
     public function getNextQuarter()

--- a/src/app/TeamMember.php
+++ b/src/app/TeamMember.php
@@ -26,8 +26,8 @@ class TeamMember extends ModelCachedRelationships
             case 'quarterNumber':
 
                 $key = "quarterNumber";
-                $quarterNumber = ModelCache::create()->get($key, $this->incomingQuarterId);
-                if ($quarterNumber === null) {
+
+                return static::getFromCache($key, $this->incomingQuarterId, function() {
 
                     $thisQuarter = Quarter::getCurrentQuarter($this->person->center->region);
 
@@ -40,12 +40,8 @@ class TeamMember extends ModelCachedRelationships
                         $quarterNumber += 4;
                     }
 
-                    $quarterNumber -= $this->incomingQuarter->quarterNumber;
-
-                    ModelCache::create()->set($key, $this->incomingQuarterId, $quarterNumber);
-                }
-
-                return $quarterNumber;
+                    return $quarterNumber - $this->incomingQuarter->quarterNumber;
+                });
             default:
                 return parent::__get($name);
         }

--- a/src/app/TmlpRegistrationData.php
+++ b/src/app/TmlpRegistrationData.php
@@ -38,19 +38,14 @@ class TmlpRegistrationData extends ModelCachedRelationships
             case 'center':
                 return $this->registration->person->$name;
             case 'incomingQuarter':
-
                 $key = "incomingQuarter:region{$this->center->regionId}";
-                $quarter = ModelCache::create()->get($key, $this->incomingQuarterId);
-                if ($quarter === null) {
+                return static::getFromCache($key, $this->incomingQuarterId, function() {
                     $quarter = Quarter::find($this->incomingQuarterId);
                     if ($quarter) {
                         $quarter->setRegion($this->center->region);
                     }
-
-                    ModelCache::create()->set($key, $this->incomingQuarterId, $quarter);
-                }
-
-                return $quarter;
+                    return $quarter;
+                });
             default:
                 return parent::__get($name);
         }


### PR DESCRIPTION
There was a bug where if a model was copied (passing by value in a function)
then relationships are used, the eager loaded relationship isn't checked and we
end up fetching the models again.

Also added method to simplify manual model cache checks