### PR TITLE
Cache reports, not objects

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -57,6 +57,11 @@ cd $DEST/
 php artisan migrate
 
 echo ""
+echo "Flushing Reports Cache"
+cd $DEST/
+php artisan cache:clear-reports
+
+echo ""
 echo "Fixing file permisssions"
 sudo chmod -R o+w $DEST/storage
 

--- a/src/app/Console/Commands/FlushReportsCacheCommand.php
+++ b/src/app/Console/Commands/FlushReportsCacheCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TmlpStats\Console\Commands;
+
+use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Command;
+
+class FlushReportsCacheCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cache:clear-reports';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear reports from cache';
+
+    /**
+     * The cache manager instance.
+     *
+     * @var \Illuminate\Cache\CacheManager
+     */
+    protected $cache;
+
+    /**
+     * Create a new command instance.
+     *
+     */
+    public function __construct(CacheManager $cache)
+    {
+        parent::__construct();
+        $this->cache = $cache;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->cache->store()->tags('reports')->flush();
+
+        $this->info('Report cache cleared!');
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel {
         Commands\FlushTablesCommand::class,
         Commands\ClearTablesCommand::class,
         Commands\ReportsWiki::class,
+        Commands\FlushReportsCacheCommand::class,
     ];
 
     /**

--- a/src/app/Http/Controllers/ContactsController.php
+++ b/src/app/Http/Controllers/ContactsController.php
@@ -2,7 +2,6 @@
 
 namespace TmlpStats\Http\Controllers;
 
-use Cache;
 use Illuminate\Http\Request;
 use TmlpStats\Accountability;
 use TmlpStats\Http\Requests;
@@ -87,34 +86,22 @@ class ContactsController extends Controller
     }
 
 
-    public function getByStatsReport($id)
+    public function getByStatsReport(StatsReport $statsReport)
     {
-        $cacheKey = "statsReport{$id}:contacts";
-        $contacts = ($this->useCache()) ? Cache::tags(["statsReport{$id}"])->get($cacheKey) : false;
-
-        if (!$contacts) {
-            $statsReport = StatsReport::find($id);
-
-            if (!$statsReport) {
-                return null;
-            }
-
-            // Contacts
-            $contacts = array();
-            $accountabilities = array(
-                'programManager',
-                'classroomLeader',
-                'team1TeamLeader',
-                'team2TeamLeader',
-                'teamStatistician',
-                'teamStatisticianApprentice',
-            );
-            foreach ($accountabilities as $accountability) {
-                $accountabilityObj = Accountability::name($accountability)->first();
-                $contacts[$accountabilityObj->display] = $statsReport->center->getAccountable($accountability);
-            }
+        // Contacts
+        $contacts = array();
+        $accountabilities = array(
+            'programManager',
+            'classroomLeader',
+            'team1TeamLeader',
+            'team2TeamLeader',
+            'teamStatistician',
+            'teamStatisticianApprentice',
+        );
+        foreach ($accountabilities as $accountability) {
+            $accountabilityObj = Accountability::name($accountability)->first();
+            $contacts[$accountabilityObj->display] = $statsReport->center->getAccountable($accountability);
         }
-        Cache::tags(["statsReport{$id}"])->put($cacheKey, $contacts, static::STATS_REPORT_CACHE_TTL);
 
         return $contacts;
     }

--- a/src/app/Http/Controllers/Controller.php
+++ b/src/app/Http/Controllers/Controller.php
@@ -2,11 +2,9 @@
 namespace TmlpStats\Http\Controllers;
 
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use Illuminate\Foundation\Bus\DispatchesCommands;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
-
 use TmlpStats\Region;
 
 use Auth;
@@ -14,11 +12,9 @@ use Session;
 
 abstract class Controller extends BaseController
 {
-    use DispatchesCommands, ValidatesRequests, AuthorizesRequests;
+    use ValidatesRequests, AuthorizesRequests;
 
-    const CACHE_TTL = 60;
-    const STATS_REPORT_CACHE_TTL = 7 * 24 * 60;
-    const USE_CACHE = true;
+    protected $region = null;
 
     /**
      * Create a new controller instance.
@@ -37,6 +33,10 @@ abstract class Controller extends BaseController
      */
     public function getRegion(Request $request, $includeLocalRegions = false)
     {
+        if ($this->region) {
+            return $this->region;
+        }
+
         $region = null;
         if ($request->has('region')) {
             $region = Region::abbreviation($request->get('region'))->first();
@@ -61,16 +61,6 @@ abstract class Controller extends BaseController
             $region = $region->getParentGlobalRegion();
         }
 
-        return $region;
-    }
-
-    /**
-     * Get setting for whether or not to use cached data
-     *
-     * @return bool
-     */
-    public function useCache()
-    {
-        return (bool)env('REPORTS_USE_CACHE', static::USE_CACHE);
+        return $this->region = $region;
     }
 }

--- a/src/app/Http/Controllers/ReportDispatchAbstractController.php
+++ b/src/app/Http/Controllers/ReportDispatchAbstractController.php
@@ -48,7 +48,7 @@ abstract class ReportDispatchAbstractController extends Controller
      */
     public function getCacheKey($model, $report)
     {
-        $keyBase = Util::getClassBasename($model);
+        $keyBase = lcfirst(Util::getClassBasename($model));
 
         return "{$keyBase}{$model->id}:{$report}";
     }

--- a/src/app/Http/Controllers/ReportDispatchAbstractController.php
+++ b/src/app/Http/Controllers/ReportDispatchAbstractController.php
@@ -1,0 +1,138 @@
+<?php
+namespace TmlpStats\Http\Controllers;
+
+use Cache;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use TmlpStats\Util;
+
+abstract class ReportDispatchAbstractController extends Controller
+{
+    const CACHE_TTL = 60;
+    const USE_CACHE = true;
+
+    /**
+     * List of reports that will not be cached
+     *
+     * @var array
+     */
+    protected $dontCache = [];
+
+    /**
+     * Returns an instance of the appropriate Model class by id
+     *
+     * MUST NOT return null.
+     * MUST return a model or abort.
+     *
+     * @param $id
+     * @return mixed
+     */
+    abstract public function getById($id);
+
+    /**
+     * Runs the appropriate logic and returns resulting view
+     *
+     * @param Request $request
+     * @param $model
+     * @param $report
+     * @return \Illuminate\View\View
+     */
+    abstract public function runDispatcher(Request $request, $model, $report);
+
+    /**
+     * Get the cache key to use for given model/report combo
+     *
+     * @param $model
+     * @param $report
+     * @return string
+     */
+    public function getCacheKey($model, $report)
+    {
+        $keyBase = Util::getClassBasename($model);
+
+        return "{$keyBase}{$model->id}:{$report}";
+    }
+
+    /**
+     * Get the tags to use when caching response.
+     *
+     * Adding tags allows you to flush a group of responses when needed
+     *
+     * @param $model
+     * @param $report
+     * @return array
+     */
+    public function getCacheTags($model, $report)
+    {
+        return ['reports'];
+    }
+
+    /**
+     * Entry method to dispatch a report
+     *
+     * Caches reponses based on response from useCache()
+     *
+     * @param Request $request
+     * @param $id
+     * @param $report
+     * @return View|string|null
+     */
+    public function dispatchReport(Request $request, $id, $report)
+    {
+        $model = $this->getById($id);
+
+        $this->authorizeReport($model, $report);
+
+        $response = null;
+
+        if ($this->useCache($report)) {
+            $cacheKey = $this->getCacheKey($model, $report);
+            $tags = $this->getCacheTags($model, $report);
+
+            $response = Cache::tags($tags)->get($cacheKey);
+        }
+
+        if (!$response) {
+            $response = $this->runDispatcher($request, $model, $report);
+        }
+
+        if ($this->useCache($report) && $response) {
+            if ($response instanceof View) {
+                $renderedResponse = $response->render();
+            } else {
+                $renderedResponse = $response;
+            }
+            Cache::tags($tags)->put($cacheKey, $renderedResponse, static::CACHE_TTL);
+        }
+
+        if (!$response) {
+            abort(404);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Authorize the report
+     *
+     * This has a sensible default. Allows additional authorization per report as needed.
+     *
+     * @param $model
+     * @param $report
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function authorizeReport($model, $report)
+    {
+        return $this->authorize('read', $model);
+    }
+
+    /**
+     * Get setting for whether or not to use cached data
+     *
+     * @return bool
+     */
+    public function useCache($report)
+    {
+        return env('REPORTS_USE_CACHE', static::USE_CACHE) && !in_array($report, $this->dontCache);
+    }
+}

--- a/src/app/Http/Controllers/StatsReportController.php
+++ b/src/app/Http/Controllers/StatsReportController.php
@@ -3,7 +3,6 @@
 use Illuminate\Http\Request;
 use TmlpStats\Center;
 use TmlpStats\GlobalReport;
-use TmlpStats\Reports\Diffs\TmlpRegistrationDiff;
 use TmlpStats\ReportToken;
 use TmlpStats\StatsReport;
 

--- a/src/app/Http/routes.php
+++ b/src/app/Http/routes.php
@@ -30,11 +30,11 @@ Route::resource('admin/users', 'UserController');
 Route::resource('statsreports', 'StatsReportController');
 Route::post('statsreports/{id}/submit', 'StatsReportController@submit');
 Route::get('statsreports/{id}/download', 'StatsReportController@downloadSheet');
-Route::get('statsreports/{id}/{report}', 'StatsReportController@runDispatcher');
+Route::get('statsreports/{id}/{report}', 'StatsReportController@dispatchReport');
 
 // Global Reports
 Route::resource('globalreports', 'GlobalReportController');
-Route::get('globalreports/{id}/{report}', 'GlobalReportController@runDispatcher');
+Route::get('globalreports/{id}/{report}', 'GlobalReportController@dispatchReport');
 
 // Report Tokens
 Route::resource('reporttokens', 'ReportTokenController');

--- a/src/app/Util.php
+++ b/src/app/Util.php
@@ -158,4 +158,17 @@ class Util
 
         return $sessions;
     }
+
+    /**
+     * Get the base classname of an object.
+     *   e.g.
+     *      \TmlpStats\StatsReport => StatsReport
+     *
+     * @param $object
+     * @return string
+     */
+    public static function getClassBasename($object)
+    {
+        return substr(strrchr(get_class($object), '\\'), 1);
+    }
 }


### PR DESCRIPTION
Switched to caching complete reports instead of partial report data. This makes
it easier to abstract the caching out of individual controllers into just the
report controllers.

Also added reports cache busting command to run during deploy.
```php artisan cache:clear-reports```