### PR TITLE
Fix the StatsReport->getPoints() calculation

### DIFF
--- a/src/app/StatsReport.php
+++ b/src/app/StatsReport.php
@@ -92,7 +92,9 @@ class StatsReport extends Model
 
     public function getPoints()
     {
-        $data = CenterStatsData::actual()->byStatsReport($this)->first();
+        $data = CenterStatsData::actual()->byStatsReport($this)
+            ->reportingDate($this->reportingDate)
+            ->first();
         return $data ? $data->points : null;
     }
 


### PR DESCRIPTION
It used to grab the first actual imported by that report and use those points. In
general that would work except when a center reports for the first time mid-quarter.
Fixed by also searching on the actual reporting date.