### PR TITLE
Fix email message sent when sheet contained errors.

### DIFF
--- a/src/resources/views/emails/statssubmitted.blade.php
+++ b/src/resources/views/emails/statssubmitted.blade.php
@@ -1,17 +1,22 @@
 Hi {{ $user }},<br/>
 <br/>
 Thank you for submitting stats for team {{ $centerName }}.
+
 @if ($isLate)
 Your stats are late. They were due on {{ $due }}.
 @endif
+
 We received them on {{ $time }} your local time. Please find the submitted sheet attached.<br/>
 <br/>
+
 @if (isset($sheet['errors']) && $sheet['errors'])
-    Your sheet contained errors. Please review the errors below and correct them for your report next week. If you have any questions please reach out to your regional statistician.<br/>
-@else
-    You are not complete yet. Your regional statistician will review your sheet and declare you complete by {{ $respondByTime }} your local time Saturday morning.<br/>
+    Your sheet contained errors. Please review the errors below and correct them. If you have any questions please reach out to your regional statistician.<br/>
+    <br/>
 @endif
+
+You are not complete yet. Your regional statistician will review your sheet and declare you complete by {{ $respondByTime }} your local time Saturday morning.<br/>
 <br/>
+
 @if ($reportUrl)
 <a href="{{ $reportUrl }}">View your report online: {{ $centerName }} - {{ $reportingDate->format('M j, Y') }}</a><br/>
 <br/>


### PR DESCRIPTION
- Updated so the message about it including errors doesn't say to complete them by next week.
- Always include message that stats aren't complete until regional declares them complete.