### PR TITLE
Overhaul importing accountabilities.

### DIFF
--- a/src/app/Accountability.php
+++ b/src/app/Accountability.php
@@ -27,6 +27,8 @@ class Accountability extends Model
 
     public function people()
     {
-        return $this->belongsToMany('TmlpStats\Person', 'accountability_person', 'accountability_id', 'person_id')->withTimestamps();
+        return $this->belongsToMany('TmlpStats\Person', 'accountability_person', 'accountability_id', 'person_id')
+            ->withPivot(['stats_at', 'ends_at'])
+            ->withTimestamps();
     }
 }

--- a/src/app/Center.php
+++ b/src/app/Center.php
@@ -38,22 +38,22 @@ class Center extends Model
 
     public function getT1TeamLeader()
     {
-        return $this->getAccountable('team1TeamLeader');
+        return $this->getAccountable('t1tl');
     }
 
     public function getT2TeamLeader()
     {
-        return $this->getAccountable('team2TeamLeader');
+        return $this->getAccountable('t2tl');
     }
 
     public function getStatistician()
     {
-        return $this->getAccountable('teamStatistician');
+        return $this->getAccountable('statistician');
     }
 
     public function getStatisticianApprentice()
     {
-        return $this->getAccountable('teamStatisticianApprentice');
+        return $this->getAccountable('statisticianApprentice');
     }
 
     public function getAccountable($accountabilityName)

--- a/src/app/Console/Commands/MergeDuplicatePeople.php
+++ b/src/app/Console/Commands/MergeDuplicatePeople.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace TmlpStats\Console\Commands;
+
+use Carbon\Carbon;
+use DB;
+use Illuminate\Console\Command;
+use TmlpStats\Accountability;
+use TmlpStats\Person;
+use TmlpStats\TeamMember;
+use TmlpStats\TmlpRegistration;
+use TmlpStats\User;
+
+class MergeDuplicatePeople extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:merge-duplicates {id1} {id2} {id3?} {id4?} {id5?} {id6?} {id7?} {id8?} {id9?} {--dry-run}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Merges duplicate people by id';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $arguments = $this->argument();
+
+        if (!$this->argument('id1')) {
+            $this->line("Provide a list of person_id's to merge. The first id will be used to overwrite the others.");
+            $this->line("Use --dry-run to see what would happen without taking the actions");
+            return 0;
+        }
+
+        $dryRun = false;
+        if ($this->option('dry-run')) {
+            $dryRun = true;
+            $this->line('Dry run selected. No data will be modified.');
+        }
+
+        $people = [];
+        foreach ($arguments as $key => $value) {
+            if (strpos($key, 'id') !== 0 || !$value) {
+                continue;
+            }
+
+            $person = Person::find($value);
+            if (!$person) {
+                $this->line("Unable to find person with id {$value}");
+                continue;
+            }
+
+            $people[] = $person;
+        }
+
+        $primary = array_shift($people);
+        $this->line("Using primary person {$primary->id}: {$primary->firstName} {$primary->lastName}");
+
+        $primaryAccountabilities = [];
+        $mappings = DB::table('accountability_person')->where('person_id', $primary->id)->get();
+        foreach ($mappings as $map) {
+            $ends = isset($map->ends_at) ? Carbon::parse($map->ends_at) : null;
+            $active = $ends ? $ends->gt(Carbon::now()) : true;
+
+            $primaryAccountabilities[$map->accountability_id] = $active;
+        }
+
+        foreach ($people as $person) {
+            $this->line("----");
+            $this->line("Inspecting person {$person->id}: {$person->firstName} {$person->lastName}");
+
+            if ($person->centerId != $primary->centerId) {
+                $this->line("Primary {$primary->id} is from {$primary->center->name}, but person {$person->id} is from {$person->center->name}. Skipping");
+                continue;
+            }
+
+            $registrations = TmlpRegistration::byPerson($person)->get();
+            if (!$registrations->isEmpty()) {
+                foreach ($registrations as $registration) {
+                    $this->line("Updating TmlpRegistration person_id from {$registration->person_id} to {$primary->id}");
+                    if (!$dryRun) {
+                        $registration->personId = $primary->id;
+                        $registration->save();
+                    }
+                }
+            } else {
+                $this->line("No TmlpRegistrations to update.");
+            }
+            $this->line("");
+
+            $members = TeamMember::byPerson($person)->get();
+            if (!$members->isEmpty()) {
+                foreach ($members as $member) {
+                    $this->line("Updating TeamMember person_id from {$member->person_id} to {$primary->id}");
+                    if (!$dryRun) {
+                        $member->personId = $primary->id;
+                        $member->save();
+                    }
+                }
+            } else {
+                $this->line("No TeamMembers to update.");
+            }
+            $this->line("");
+
+            $users = User::byPerson($person)->get();
+            if (!$users->isEmpty()) {
+                foreach ($users as $user) {
+                    $this->line("Updating User person_id from {$user->person_id} to {$primary->id}");
+                    if (!$dryRun) {
+                        $user->personId = $primary->id;
+                        $user->save();
+                    }
+                }
+            } else {
+                $this->line("No Users to update.");
+            }
+            $this->line("");
+
+            $accountabilitiesMappings = DB::table('accountability_person')->where('person_id', $person->id)->get();
+            if ($accountabilitiesMappings) {
+                foreach ($accountabilitiesMappings as $mapping) {
+                    $accountability = Accountability::find($mapping->accountability_id);
+
+                    $ends = isset($mapping->ends_at) ? Carbon::parse($mapping->ends_at) : null;
+                    $active = $ends ? $ends->gt(Carbon::now()) : true;
+
+                    // Only upgrade accountabilities
+                    if (!isset($primaryAccountabilities[$accountability->id]) || ($active && !$primaryAccountabilities[$accountability->id])) {
+                        $endsString = $ends ? $ends->toDateTimeString() : 'never';
+                        $this->line("Adding accountability {$accountability->name} which expires {$endsString}");
+                        if (!$dryRun) {
+                            DB::table('accountability_person')
+                                ->where('person_id', $person->id)
+                                ->where('accountability_id', $accountability->id)
+                                ->update(['person_id' => $primary->id]);
+                        }
+                        $primaryAccountabilities[$accountability->id] = true;
+                    } else {
+                        $this->line("Primary already has accountability {$accountability->name}. Deleting");
+                        if (!$dryRun) {
+                            DB::table('accountability_person')
+                                ->where('person_id', $person->id)
+                                ->where('accountability_id', $accountability->id)
+                                ->delete();
+                        }
+                    }
+                }
+            } else {
+                $this->line("No Accountabilities to add.");
+            }
+            $this->line("");
+
+            if (!$primary->email && $person->email && $person->email != $primary->email) {
+                $this->line("Adding email {$person->email}");
+                if (!$dryRun) {
+                    $primary->email = $person->email;
+                }
+            }
+
+            if (!$primary->phone && $person->phone && $person->phone != $primary->phone) {
+                $this->line("Adding phone {$person->phone}");
+                if (!$dryRun) {
+                    $primary->phone = $person->phone;
+                }
+            }
+            if (!$dryRun && $primary->isDirty()) {
+                $primary->save();
+            }
+            $this->line("");
+
+            $this->line("Deleting person {$person->id}");
+            if (!$dryRun) {
+                $person->delete();
+            }
+        }
+        $this->line("----");
+
+        $this->line("Done");
+    }
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends ConsoleKernel {
         Commands\ReportsWiki::class,
         Commands\FlushReportsCacheCommand::class,
         Commands\SanitizeDb::class,
+        Commands\MergeDuplicatePeople::class,
     ];
 
     /**

--- a/src/app/Http/Controllers/ContactsController.php
+++ b/src/app/Http/Controllers/ContactsController.php
@@ -85,7 +85,6 @@ class ContactsController extends Controller
         //
     }
 
-
     public function getByStatsReport(StatsReport $statsReport)
     {
         // Contacts
@@ -93,10 +92,10 @@ class ContactsController extends Controller
         $accountabilities = array(
             'programManager',
             'classroomLeader',
-            'team1TeamLeader',
-            'team2TeamLeader',
-            'teamStatistician',
-            'teamStatisticianApprentice',
+            't1tl',
+            't2tl',
+            'statistician',
+            'statisticianApprentice',
         );
         foreach ($accountabilities as $accountability) {
             $accountabilityObj = Accountability::name($accountability)->first();

--- a/src/app/Message.php
+++ b/src/app/Message.php
@@ -13,698 +13,729 @@ class Message
     const DEBUG = 8;
 
     // Message Definitions
-    static $messageList = array(
+    static $messageList = [
         // General Errors
-        'INVALID_VALUE'                                                 => array(
+        'INVALID_VALUE'                                                 => [
             'type'      => Message::ERROR,
             'format'    => "Incorrect value provided for %%display_name%% ('%%value%%').",
-            'arguments' => array(
+            'arguments' => [
                 '%%display_name%%',
                 '%%value%%',
-            ),
-        ),
-        'IMPORT_TAB_FAILED'                                             => array(
+            ],
+        ],
+        'IMPORT_TAB_FAILED'                                             => [
             'type'      => Message::ERROR,
             'format'    => "Unable to import tab.",
-            'arguments' => array(),
-        ),
-        'EXCEPTION_LOADING_ENTRY'                                       => array(
+            'arguments' => [],
+        ],
+        'EXCEPTION_LOADING_ENTRY'                                       => [
             'type'      => Message::ERROR,
             'format'    => "There was an error processing tab: %%message%%.",
-            'arguments' => array(
+            'arguments' => [
                 '%%message%%',
-            ),
-        ),
+            ],
+        ],
 
         // TMLP Registration Validator Errors
-        'TMLPREG_MULTIPLE_WEEKENDREG'                                   => array(
+        'TMLPREG_MULTIPLE_WEEKENDREG'                                   => [
             'type'      => Message::ERROR,
             'format'    => "Weekend Reg section contains multiple %%incomingTeamYear%%'s. Only one should be provided",
-            'arguments' => array(
+            'arguments' => [
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_WD_MISSING'                                            => array(
+            ],
+        ],
+        'TMLPREG_WD_MISSING'                                            => [
             'type'      => Message::ERROR,
             'format'    => "Withdraw date was provided, but '%%offset%%' column does not contain a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_WD_DATE_MISSING'                                       => array(
+            ],
+        ],
+        'TMLPREG_WD_DATE_MISSING'                                       => [
             'type'      => Message::ERROR,
             'format'    => "No withdraw date was provided, but '%%offset%%' column contains a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_WD_DOESNT_MATCH_INCOMING_YEAR'                         => array(
+            ],
+        ],
+        'TMLPREG_WD_DOESNT_MATCH_INCOMING_YEAR'                         => [
             'type'      => Message::ERROR,
             'format'    => "The program year specified for WD doesn't match the incoming program year. It should match the value in the Weekend Reg columns",
-            'arguments' => array(),
-        ),
-        'TMLPREG_WD_ONLY_ONE_YEAR_INDICATOR'                            => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_WD_ONLY_ONE_YEAR_INDICATOR'                            => [
             'type'      => Message::ERROR,
             'format'    => "If person has withdrawn, only column '%%offset%%' should contain a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPR_MISSING'                                          => array(
+            ],
+        ],
+        'TMLPREG_APPR_MISSING'                                          => [
             'type'      => Message::ERROR,
             'format'    => "Approved date was provided, but '%%offset%%' column does not contain a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPR_DATE_MISSING'                                     => array(
+            ],
+        ],
+        'TMLPREG_APPR_DATE_MISSING'                                     => [
             'type'      => Message::ERROR,
             'format'    => "No approved date was provided, but '%%offset%%' column contains a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPR_ONLY_ONE_YEAR_INDICATOR'                          => array(
+            ],
+        ],
+        'TMLPREG_APPR_ONLY_ONE_YEAR_INDICATOR'                          => [
             'type'      => Message::ERROR,
             'format'    => "If person is approved, only column '%%offset%%' should contain a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPR_MISSING_APPIN_DATE'                               => array(
+            ],
+        ],
+        'TMLPREG_APPR_MISSING_APPIN_DATE'                               => [
             'type'      => Message::ERROR,
             'format'    => "No app in date provided",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPR_MISSING_APPOUT_DATE'                              => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPR_MISSING_APPOUT_DATE'                              => [
             'type'      => Message::ERROR,
             'format'    => "No app out date provided",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPIN_MISSING'                                         => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPIN_MISSING'                                         => [
             'type'      => Message::ERROR,
             'format'    => "App in date was provided, but '%%offset%%' column does not contain a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPIN_DATE_MISSING'                                    => array(
+            ],
+        ],
+        'TMLPREG_APPIN_DATE_MISSING'                                    => [
             'type'      => Message::ERROR,
             'format'    => "No app in date was provided, but '%%offset%%' column contains a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPIN_ONLY_ONE_YEAR_INDICATOR'                         => array(
+            ],
+        ],
+        'TMLPREG_APPIN_ONLY_ONE_YEAR_INDICATOR'                         => [
             'type'      => Message::ERROR,
             'format'    => "If person's application is in, only column '%%offset%%' should contain a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPIN_MISSING_APPOUT_DATE'                             => array(
+            ],
+        ],
+        'TMLPREG_APPIN_MISSING_APPOUT_DATE'                             => [
             'type'      => Message::ERROR,
             'format'    => "No app out date provided",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPOUT_MISSING'                                        => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPOUT_MISSING'                                        => [
             'type'      => Message::ERROR,
             'format'    => "App out date was provided, but '%%offset%%' column does not contain a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_APPOUT_DATE_MISSING'                                   => array(
+            ],
+        ],
+        'TMLPREG_APPOUT_DATE_MISSING'                                   => [
             'type'      => Message::ERROR,
             'format'    => "No app out date was provided, but '%%offset%%' column contains a %%incomingTeamYear%%",
-            'arguments' => array(
+            'arguments' => [
                 '%%offset%%',
                 '%%incomingTeamYear%%',
-            ),
-        ),
-        'TMLPREG_NO_COMMITTED_TEAM_MEMBER'                              => array(
+            ],
+        ],
+        'TMLPREG_NO_COMMITTED_TEAM_MEMBER'                              => [
             'type'      => Message::ERROR,
             'format'    => "No committed team member provided",
-            'arguments' => array(),
-        ),
-        'TMLPREG_WD_DATE_BEFORE_REG_DATE'                               => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_COMMITTED_TEAM_MEMBER_NO_MATCHING_TEAM_MEMBER'         => [
+            'type'      => Message::WARNING,
+            'format'    => "Unable to find a team member with the name %%name%% on the Class List for committed team member. Please make sure the first name and last initial match the team member exactly.",
+            'arguments' => [
+                '%%name%%',
+            ],
+        ],
+        'TMLPREG_WD_DATE_BEFORE_REG_DATE'                               => [
             'type'      => Message::ERROR,
             'format'    => "Withdraw date is before registration date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_WD_DATE_BEFORE_APPR_DATE'                              => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_WD_DATE_BEFORE_APPR_DATE'                              => [
             'type'      => Message::ERROR,
             'format'    => "Withdraw date is before approval date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_WD_DATE_BEFORE_APPIN_DATE'                             => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_WD_DATE_BEFORE_APPIN_DATE'                             => [
             'type'      => Message::ERROR,
             'format'    => "Withdraw date is before app in date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_WD_DATE_BEFORE_APPOUT_DATE'                            => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_WD_DATE_BEFORE_APPOUT_DATE'                            => [
             'type'      => Message::ERROR,
             'format'    => "Withdraw date is before app out date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPR_DATE_BEFORE_REG_DATE'                             => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPR_DATE_BEFORE_REG_DATE'                             => [
             'type'      => Message::ERROR,
             'format'    => "Approval date is before registration date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPR_DATE_BEFORE_APPIN_DATE'                           => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPR_DATE_BEFORE_APPIN_DATE'                           => [
             'type'      => Message::ERROR,
             'format'    => "Approval date is before app in date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPR_DATE_BEFORE_APPOUT_DATE'                          => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPR_DATE_BEFORE_APPOUT_DATE'                          => [
             'type'      => Message::ERROR,
             'format'    => "Approval date is before app out date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPIN_DATE_BEFORE_REG_DATE'                            => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPIN_DATE_BEFORE_REG_DATE'                            => [
             'type'      => Message::ERROR,
             'format'    => "App in date is before registration date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPIN_DATE_BEFORE_APPOUT_DATE'                         => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPIN_DATE_BEFORE_APPOUT_DATE'                         => [
             'type'      => Message::ERROR,
             'format'    => "App in date is before app out date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPOUT_DATE_BEFORE_REG_DATE'                           => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPOUT_DATE_BEFORE_REG_DATE'                           => [
             'type'      => Message::ERROR,
             'format'    => "App out date is before registration date",
-            'arguments' => array(),
-        ),
-        'TMLPREG_BEF_REG_DATE_NOT_BEFORE_WEEKEND'                       => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_BEF_REG_DATE_NOT_BEFORE_WEEKEND'                       => [
             'type'      => Message::ERROR,
             'format'    => "Registration is not before the quarter's start date (%%date%%) but has a %%value%% in Bef column",
-            'arguments' => array(
+            'arguments' => [
                 '%%date%%',
                 '%%value%%',
-            ),
-        ),
-        'TMLPREG_DUR_REG_DATE_NOT_DURING_WEEKEND'                       => array(
+            ],
+        ],
+        'TMLPREG_DUR_REG_DATE_NOT_DURING_WEEKEND'                       => [
             'type'      => Message::ERROR,
             'format'    => "Registration date is not during quarter start weekend (%%date%%) but has a %%value%% in Dur column",
-            'arguments' => array(
+            'arguments' => [
                 '%%date%%',
                 '%%value%%',
-            ),
-        ),
-        'TMLPREG_AFT_REG_DATE_NOT_AFTER_WEEKEND'                        => array(
+            ],
+        ],
+        'TMLPREG_AFT_REG_DATE_NOT_AFTER_WEEKEND'                        => [
             'type'      => Message::ERROR,
             'format'    => "Registration date is not after quarter start date (%%date%%) but has a %%value%% in Aft column",
-            'arguments' => array(
+            'arguments' => [
                 '%%date%%',
                 '%%value%%',
-            ),
-        ),
-        'TMLPREG_APPOUT_LATE'                                           => array(
+            ],
+        ],
+        'TMLPREG_APPOUT_LATE'                                           => [
             'type'      => Message::WARNING,
             'format'    => "Application was not sent to applicant within %%daysSince%% days of registration.",
-            'arguments' => array(
+            'arguments' => [
                 '%%daysSince%%',
-            ),
-        ),
-        'TMLPREG_APPIN_LATE'                                            => array(
+            ],
+        ],
+        'TMLPREG_APPIN_LATE'                                            => [
             'type'      => Message::WARNING,
             'format'    => "Application not returned within %%daysSince%% days since sending application out. Application is not in integrity with design of application process.",
-            'arguments' => array(
+            'arguments' => [
                 '%%daysSince%%',
-            ),
-        ),
-        'TMLPREG_APPR_LATE'                                             => array(
+            ],
+        ],
+        'TMLPREG_APPR_LATE'                                             => [
             'type'      => Message::WARNING,
             'format'    => "Application not approved within %%daysSince%% days since sending application out.",
-            'arguments' => array(
+            'arguments' => [
                 '%%daysSince%%',
-            ),
-        ),
-        'TMLPREG_REG_DATE_IN_FUTURE'                                    => array(
+            ],
+        ],
+        'TMLPREG_REG_DATE_IN_FUTURE'                                    => [
             'type'      => Message::ERROR,
             'format'    => "Registration date is in the future. Please check date.",
-            'arguments' => array(),
-        ),
-        'TMLPREG_WD_DATE_IN_FUTURE'                                     => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_WD_DATE_IN_FUTURE'                                     => [
             'type'      => Message::ERROR,
             'format'    => "Withdraw date is in the future. Please check date.",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPR_DATE_IN_FUTURE'                                   => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPR_DATE_IN_FUTURE'                                   => [
             'type'      => Message::ERROR,
             'format'    => "Approve date is in the future. Please check date.",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPIN_DATE_IN_FUTURE'                                  => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPIN_DATE_IN_FUTURE'                                  => [
             'type'      => Message::ERROR,
             'format'    => "Application In date is in the future. Please check date.",
-            'arguments' => array(),
-        ),
-        'TMLPREG_APPOUT_DATE_IN_FUTURE'                                 => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_APPOUT_DATE_IN_FUTURE'                                 => [
             'type'      => Message::ERROR,
             'format'    => "Application Out date is in the future. Please check date.",
-            'arguments' => array(),
-        ),
-        'TMLPREG_COMMENT_MISSING_FUTURE_WEEKEND'                        => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_COMMENT_MISSING_FUTURE_WEEKEND'                        => [
             'type'      => Message::ERROR,
             'format'    => "No comment provided specifying incoming weekend for future registration",
-            'arguments' => array(),
-        ),
-        'TMLPREG_TRAVEL_COMMENT_MISSING'                                => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_TRAVEL_COMMENT_MISSING'                                => [
             'type'      => Message::ERROR,
             'format'    => "Either travel must be complete and marked with a Y in the Travel column, or a comment with a specific promise must be provided",
-            'arguments' => array(),
-        ),
-        'TMLPREG_ROOM_COMMENT_MISSING'                                  => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_ROOM_COMMENT_MISSING'                                  => [
             'type'      => Message::ERROR,
             'format'    => "Either rooming must be complete and marked with a Y in the Room column, or a comment with a specific promise must be provided",
-            'arguments' => array(),
-        ),
-        'TMLPREG_TRAVEL_COMMENT_REVIEW'                                 => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_TRAVEL_COMMENT_REVIEW'                                 => [
             'type'      => Message::WARNING,
             'format'    => "Travel is not booked. Make sure the comment provides a specific promise for when travel will be complete.",
-            'arguments' => array(),
-        ),
-        'TMLPREG_ROOM_COMMENT_REVIEW'                                   => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_ROOM_COMMENT_REVIEW'                                   => [
             'type'      => Message::WARNING,
             'format'    => "Rooming is not booked. Make sure the comment provides a specific promise for when rooming will be complete.",
-            'arguments' => array(),
-        ),
-        'TMLPREG_TRAVEL_ROOM_CTW_COMMENT_REVIEW'                        => array(
+            'arguments' => [],
+        ],
+        'TMLPREG_TRAVEL_ROOM_CTW_COMMENT_REVIEW'                        => [
             'type'      => Message::WARNING,
             'format'    => "Travel/rooming are not complete by 2 weeks before the end of the quarter. Make sure the comment states that they are in a Conversation To Withdraw (CTW).",
-            'arguments' => array(),
-        ),
+            'arguments' => [],
+        ],
+        'TMLPREG_DUPLICATE_NAME'                                        => [
+            'type'      => Message::ERROR,
+            'format'    => "There are multiple registrations with the name '%%firstName%% %%lastName%%'. You may have accidentally added them twice. If you have 2 people with the same first name and last initial, please provide an additional letter of their last name so we can tell them apart. Make sure to use the same spelling if you reference them on other tabs.",
+            'arguments' => [
+                '%%firstName%%',
+                '%%lastName%%',
+            ],
+        ],
 
         // TMLP Course Info Errors
-        'TMLPCOURSE_QSTART_TER_LESS_THAN_QSTART_APPROVED'               => array(
+        'TMLPCOURSE_QSTART_TER_LESS_THAN_QSTART_APPROVED'               => [
             'type'      => Message::ERROR,
             'format'    => "Quarter Starting Total Registered is less than Quarter Starting Total Approved. Starting Registered should include Approved applications.",
-            'arguments' => array(),
-        ),
+            'arguments' => [],
+        ],
 
         // Communication Course Info Errors
-        'COMMCOURSE_COMPLETED_SS_MISSING'                               => array(
+        'COMMCOURSE_COMPLETED_SS_MISSING'                               => [
             'type'      => Message::ERROR,
             'format'    => "Course has completed but is missing Standard Starts Completed",
-            'arguments' => array(),
-        ),
-        'COMMCOURSE_POTENTIALS_MISSING'                                 => array(
+            'arguments' => [],
+        ],
+        'COMMCOURSE_POTENTIALS_MISSING'                                 => [
             'type'      => Message::ERROR,
             'format'    => "Course has completed but is missing Potentials",
-            'arguments' => array(),
-        ),
-        'COMMCOURSE_REGISTRATIONS_MISSING'                              => array(
+            'arguments' => [],
+        ],
+        'COMMCOURSE_REGISTRATIONS_MISSING'                              => [
             'type'      => Message::ERROR,
             'format'    => "Course has completed but is missing Registrations",
-            'arguments' => array(),
-        ),
-        'COMMCOURSE_COMPLETION_STATS_PROVIDED_BEFORE_COURSE'            => array(
+            'arguments' => [],
+        ],
+        'COMMCOURSE_COMPLETION_STATS_PROVIDED_BEFORE_COURSE'            => [
             'type'      => Message::ERROR,
             'format'    => "Course Completion stats provided, but course has not completed.",
-            'arguments' => array(),
-        ),
-        'COMMCOURSE_COMPLETED_SS_LESS_THAN_CURRENT_SS'                  => array(
+            'arguments' => [],
+        ],
+        'COMMCOURSE_COMPLETED_SS_LESS_THAN_CURRENT_SS'                  => [
             'type'      => Message::WARNING,
             'format'    => "Completed Standard Starts is %%difference%% less than the course starting standard starts. Confirm with your regional statistician that %%difference%% people did withdraw during the course.",
-            'arguments' => array(
+            'arguments' => [
                 '%%difference%%',
-            ),
-        ),
-        'COMMCOURSE_COMPLETED_SS_GREATER_THAN_CURRENT_SS'               => array(
+            ],
+        ],
+        'COMMCOURSE_COMPLETED_SS_GREATER_THAN_CURRENT_SS'               => [
             'type'      => Message::ERROR,
             'format'    => "More people completed the course than there were that started. Make sure Current Standard Starts matches the number of people that started the course, and Completed Standard Starts matches the number of people that completed the course.",
-            'arguments' => array(),
-        ),
-        'COMMCOURSE_COURSE_DATE_BEFORE_QUARTER'                         => array(
+            'arguments' => [],
+        ],
+        'COMMCOURSE_COURSE_DATE_BEFORE_QUARTER'                         => [
             'type'      => Message::ERROR,
             'format'    => "Course occured before quarter started",
-            'arguments' => array(),
-        ),
-        'COMMCOURSE_QSTART_SS_GREATER_THAN_QSTART_TER'                  => array(
+            'arguments' => [],
+        ],
+        'COMMCOURSE_QSTART_SS_GREATER_THAN_QSTART_TER'                  => [
             'type'      => Message::ERROR,
             'format'    => "Quarter Starting Standard Starts (%%starts%%) cannot be more than the quarter starting total number of people ever registered in the course (%%ter%%)",
-            'arguments' => array(
+            'arguments' => [
                 '%%starts%%',
                 '%%ter%%',
-            ),
-        ),
-        'COMMCOURSE_QSTART_XFER_GREATER_THAN_QSTART_TER'                => array(
+            ],
+        ],
+        'COMMCOURSE_QSTART_XFER_GREATER_THAN_QSTART_TER'                => [
             'type'      => Message::ERROR,
             'format'    => "Quarter Starting Transfer in from Earlier (%%xfer%%) cannot be more than the quarter starting total number of people ever registered in the course (%%ter%%)",
-            'arguments' => array(
+            'arguments' => [
                 '%%xfer%%',
                 '%%ter%%',
-            ),
-        ),
-        'COMMCOURSE_CURRENT_SS_GREATER_THAN_CURRENT_TER'                => array(
+            ],
+        ],
+        'COMMCOURSE_CURRENT_SS_GREATER_THAN_CURRENT_TER'                => [
             'type'      => Message::ERROR,
             'format'    => "Current Standard Starts (%%starts%%) cannot be more than the total number of people ever registered in the course (%%ter%%)",
-            'arguments' => array(
+            'arguments' => [
                 '%%starts%%',
                 '%%ter%%',
-            ),
-        ),
-        'COMMCOURSE_CURRENT_XFER_GREATER_THAN_CURRENT_TER'              => array(
+            ],
+        ],
+        'COMMCOURSE_CURRENT_XFER_GREATER_THAN_CURRENT_TER'              => [
             'type'      => Message::ERROR,
             'format'    => "Current Transfer in from Earlier (%%xfer%%) cannot be more than the total number of people ever registered in the course (%%ter%%)",
-            'arguments' => array(
+            'arguments' => [
                 '%%xfer%%',
                 '%%ter%%',
-            ),
-        ),
-        'COMMCOURSE_CURRENT_TER_LESS_THAN_QSTART_TER'                   => array(
+            ],
+        ],
+        'COMMCOURSE_CURRENT_TER_LESS_THAN_QSTART_TER'                   => [
             'type'      => Message::WARNING,
             'format'    => "Current Total Ever Registered (%%currentTer%%) is less than Quarter Starting Total Ever Registered (%%quarterStartTer%%). Please verify that this is accurate.",
-            'arguments' => array(
+            'arguments' => [
                 '%%currentTer%%',
                 '%%quarterStartTer%%',
-            ),
-        ),
-        'COMMCOURSE_CURRENT_XFER_LESS_THAN_QSTART_XFER'                 => array(
+            ],
+        ],
+        'COMMCOURSE_CURRENT_XFER_LESS_THAN_QSTART_XFER'                 => [
             'type'      => Message::WARNING,
             'format'    => "Current Transfer in from Earlier (%%currentXfer%%) is less than the Quarter Starting Transfer in from Earlier (%%quarterStartXfer%%). This should only be possible if some who previously transferred was withdrawn as a registration error.",
-            'arguments' => array(
+            'arguments' => [
                 '%%currentXfer%%',
                 '%%quarterStartXfer%%',
-            ),
-        ),
+            ],
+        ],
 
         // Class List Errors
-        'CLASSLIST_GITW_LEAVE_BLANK'                                    => array(
+        'CLASSLIST_GITW_LEAVE_BLANK'                                    => [
             'type'      => Message::ERROR,
             'format'    => "If team member is no longer on your team, leave GITW empty.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_GITW_MISSING'                                        => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_GITW_MISSING'                                        => [
             'type'      => Message::ERROR,
             'format'    => "No value provided for GITW.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_TDO_LEAVE_BLANK'                                     => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_TDO_LEAVE_BLANK'                                     => [
             'type'      => Message::ERROR,
             'format'    => "If team member is no longer on your team, leave TDO empty.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_TDO_MISSING'                                         => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_TDO_MISSING'                                         => [
             'type'      => Message::ERROR,
             'format'    => "No value provided for TDO.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_WKND_MISSING'                                        => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_WKND_MISSING'                                        => [
             'type'      => Message::ERROR,
             'format'    => "No value provided for Wknd or X In. One should be %%teamYear%%.",
-            'arguments' => array(
+            'arguments' => [
                 '%%teamYear%%',
-            ),
-        ),
-        'CLASSLIST_WKND_XIN_ONLY_ONE'                                   => array(
+            ],
+        ],
+        'CLASSLIST_WKND_XIN_ONLY_ONE'                                   => [
             'type'      => Message::ERROR,
             'format'    => "Only one of Wknd and X In should have a '%%teamYear%%'.",
-            'arguments' => array(
+            'arguments' => [
                 '%%teamYear%%',
-            ),
-        ),
-        'CLASSLIST_XFER_CHECK_WITH_OTHER_CENTER'                        => array(
+            ],
+        ],
+        'CLASSLIST_XFER_CHECK_WITH_OTHER_CENTER'                        => [
             'type'      => Message::WARNING,
             'format'    => "Team member is transferring. Confirm with other center that team member is reported appropriately on their sheet.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_XFER_COMMENT_MISSING'                                => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_XFER_COMMENT_MISSING'                                => [
             'type'      => Message::ERROR,
             'format'    => "Add a comment specifying the date of transfer and the center they transferred to/from.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_WD_WBO_ONLY_ONE'                                     => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_WD_WBO_ONLY_ONE'                                     => [
             'type'      => Message::ERROR,
             'format'    => "Both WD and WBO are set. Only one should be set.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_WD_CTW_ONLY_ONE'                                     => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_WD_CTW_ONLY_ONE'                                     => [
             'type'      => Message::ERROR,
             'format'    => "Both WD/WBO and CTW are set. CTW should not be set after the team member has withdrawn.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_WD_DOESNT_MATCH_YEAR'                                => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_WD_DOESNT_MATCH_YEAR'                                => [
             'type'      => Message::ERROR,
             'format'    => "The program year specified for WD doesn't match the team members program year. It should match the value in Wknd or X In",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_WD_COMMENT_MISSING'                                  => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_WD_COMMENT_MISSING'                                  => [
             'type'      => Message::ERROR,
             'format'    => "Add a comment with the date of withdraw.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_CTW_COMMENT_MISSING'                                 => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_CTW_COMMENT_MISSING'                                 => [
             'type'      => Message::ERROR,
             'format'    => "Add a comment with the issue/concern.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_TRAVEL_COMMENT_MISSING'                              => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_TRAVEL_COMMENT_MISSING'                              => [
             'type'      => Message::ERROR,
             'format'    => "Either travel must be complete and marked with a Y in the Travel column, or a comment providing a specific promise must be provided",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_ROOM_COMMENT_MISSING'                                => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_ROOM_COMMENT_MISSING'                                => [
             'type'      => Message::ERROR,
             'format'    => "Either rooming must be complete and marked with a Y in the Room column, or a comment providing a specific promise must be provided",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_TRAVEL_COMMENT_REVIEW'                               => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_TRAVEL_COMMENT_REVIEW'                               => [
             'type'      => Message::WARNING,
             'format'    => "Travel is not booked. Make sure the comment provides a specific promise for when travel will be complete.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_ROOM_COMMENT_REVIEW'                                 => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_ROOM_COMMENT_REVIEW'                                 => [
             'type'      => Message::WARNING,
             'format'    => "Rooming is not booked. Make sure the comment provides a specific promise for when rooming will be complete.",
-            'arguments' => array(),
-        ),
-        'CLASSLIST_TRAVEL_ROOM_CTW_MISSING'                             => array(
+            'arguments' => [],
+        ],
+        'CLASSLIST_TRAVEL_ROOM_CTW_MISSING'                             => [
             'type'      => Message::ERROR,
             'format'    => "If travel and rooming are not complete by 2 weeks before the end of the quarter, mark the team member as a Conversation To Withdraw (CTW).",
-            'arguments' => array(),
-        ),
+            'arguments' => [],
+        ],
+        'CLASSLIST_DUPLICATE_TEAM_MEMBER'                               => [
+            'type'      => Message::ERROR,
+            'format'    => "There are multiple team members with the name '%%firstName%% %%lastName%%'. You may have accidentally added them twice. If you have 2 people with the same first name and last initial, please provide an additional letter of their last name so we can tell them apart. Make sure to use the same spelling if you reference them on other tabs.",
+            'arguments' => [
+                '%%firstName%%',
+                '%%lastName%%',
+            ],
+        ],
 
         // ImportDocument Errors
-        'IMPORTDOC_QSTART_TER_DOESNT_MATCH_REG_BEFORE_WEEKEND'          => array(
+        'IMPORTDOC_QSTART_TER_DOESNT_MATCH_REG_BEFORE_WEEKEND'          => [
             'type'      => Message::ERROR,
             'format'    => "The %%type%% Quarter Starting Total Registered value you reported (%%reported%%) does not match the number of incoming with registered dates before the quarter's start date (%%calculated%%).",
-            'arguments' => array(
+            'arguments' => [
                 '%%type%%',
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_QSTART_APPROVED_DOESNT_MATCH_APPR_BEFORE_WEEKEND'    => array(
+            ],
+        ],
+        'IMPORTDOC_QSTART_APPROVED_DOESNT_MATCH_APPR_BEFORE_WEEKEND'    => [
             'type'      => Message::ERROR,
             'format'    => "The %%type%% Quarter Starting Total Approved value you reported (%%quarterStartApproved%%) does not match the number of incoming with approved dates before the quarter's start date (%%calculated%%).",
-            'arguments' => array(
+            'arguments' => [
                 '%%type%%',
                 '%%quarterStartApproved%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_QSTART_T1_TER_DOESNT_MATCH_REG_BEFORE_WEEKEND'       => array(
+            ],
+        ],
+        'IMPORTDOC_QSTART_T1_TER_DOESNT_MATCH_REG_BEFORE_WEEKEND'       => [
             'type'      => Message::WARNING,
             'format'    => "The T1 Quarter Starting Total Registered totals reported (%%reported%%) do not match the number of incoming with registered dates before the quarter's start date (%%calculated%%). Did someone transfer from another center?",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_QSTART_T1_APPROVED_DOESNT_MATCH_APPR_BEFORE_WEEKEND' => array(
+            ],
+        ],
+        'IMPORTDOC_QSTART_T1_APPROVED_DOESNT_MATCH_APPR_BEFORE_WEEKEND' => [
             'type'      => Message::WARNING,
             'format'    => "The T1 Quarter Starting Total Approved totals reported (%%reported%%) do not match the number of incoming with approved dates before the quarter's start date (%%calculated%%). Did someone transfer from another center?",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_QSTART_T2_TER_DOESNT_MATCH_REG_BEFORE_WEEKEND'       => array(
+            ],
+        ],
+        'IMPORTDOC_QSTART_T2_TER_DOESNT_MATCH_REG_BEFORE_WEEKEND'       => [
             'type'      => Message::WARNING,
             'format'    => "The T2 Quarter Starting Total Registered totals reported (%%reported%%) do not match the number of incoming with registered dates before the quarter's start date (%%calculated%%). Did someone transfer from another center?",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_QSTART_T2_APPROVED_DOESNT_MATCH_APPR_BEFORE_WEEKEND' => array(
+            ],
+        ],
+        'IMPORTDOC_QSTART_T2_APPROVED_DOESNT_MATCH_APPR_BEFORE_WEEKEND' => [
             'type'      => Message::WARNING,
             'format'    => "The T2 Quarter Starting Total Approved totals reported (%%reported%%) do not match the number of incoming with approved dates before the quarter's start date (%%calculated%%). Did someone transfer from another center?",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
+            ],
+        ],
 
-        'IMPORTDOC_CAP_ACTUAL_INCORRECT'                => array(
+        'IMPORTDOC_CAP_ACTUAL_INCORRECT'                => [
             'type'      => Message::ERROR,
             'format'    => "The CAP actual that you reported this week (%%reported%%) does not match the net number of CAP registrations this quarter (%%calculated%%).",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_CPC_ACTUAL_INCORRECT'                => array(
+            ],
+        ],
+        'IMPORTDOC_CPC_ACTUAL_INCORRECT'                => [
             'type'      => Message::ERROR,
             'format'    => "The CPC actual that you reported this week (%%reported%%) does not match the net number of CPC registrations this quarter (%%calculated%%).",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_T1X_ACTUAL_INCORRECT'                => array(
+            ],
+        ],
+        'IMPORTDOC_T1X_ACTUAL_INCORRECT'                => [
             'type'      => Message::WARNING,
             'format'    => "The T1X actual that you reported this week (%%reported%%) does not match the net number of T1 incoming approved this quarter (%%calculated%%). If the sheet does flag this in purple, the quarter starting totals are likely inaccurate.",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_T2X_ACTUAL_INCORRECT'                => array(
+            ],
+        ],
+        'IMPORTDOC_T2X_ACTUAL_INCORRECT'                => [
             'type'      => Message::WARNING,
             'format'    => "The T2X actual that you reported this week (%%reported%%) does not match the net number of T2 incoming approved this quarter (%%calculated%%). If the sheet does flag this in purple, the quarter starting totals are likely inaccurate.",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_GITW_ACTUAL_INCORRECT'               => array(
+            ],
+        ],
+        'IMPORTDOC_GITW_ACTUAL_INCORRECT'               => [
             'type'      => Message::ERROR,
             'format'    => "The GITW actual that you reported this week (%%reported%%%) does not match the percentage of team members reported as effective (%%calculated%%%).",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%calculated%%',
-            ),
-        ),
-        'IMPORTDOC_SPREADSHEET_VERSION_MISMATCH'        => array(
+            ],
+        ],
+        'IMPORTDOC_SPREADSHEET_VERSION_MISMATCH'        => [
             'type'      => Message::ERROR,
             'format'    => "Spreadsheet version (%%reported%%) doesn't match expected version (%%expected%%).",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%expected%%',
-            ),
-        ),
-        'IMPORTDOC_SPREADSHEET_DATE_MISMATCH'           => array(
+            ],
+        ],
+        'IMPORTDOC_SPREADSHEET_DATE_MISMATCH'           => [
             'type'      => Message::ERROR,
             'format'    => "Spreadsheet date (%%reported%%) doesn't match expected date (%%expected%%).",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%expected%%',
-            ),
-        ),
-        'IMPORTDOC_SPREADSHEET_DATE_MISMATCH_LAST_WEEK' => array(
+            ],
+        ],
+        'IMPORTDOC_SPREADSHEET_DATE_MISMATCH_LAST_WEEK' => [
             'type'      => Message::ERROR,
             'format'    => "Spreadsheet date (%%reported%%) doesn't match expected date (%%expected%%). If this is the last week of the quarter and you are reporting preliminary results, use Friday's date.",
-            'arguments' => array(
+            'arguments' => [
                 '%%reported%%',
                 '%%expected%%',
-            ),
-        ),
+            ],
+        ],
 
-        'IMPORTDOC_CENTER_NOT_FOUND'              => array(
+        'IMPORTDOC_CENTER_NOT_FOUND'              => [
             'type'      => Message::ERROR,
             'format'    => "Could not find center '%%centerName%%'. The name may not match our list or this sheet may be an invalid/corrupt. Make sure the center name is the same as one in this list: %%centerList%%.",
-            'arguments' => array(
+            'arguments' => [
                 '%%centerName%%',
                 '%%centerList%%',
-            ),
-        ),
-        'IMPORTDOC_CENTER_INACTIVE'               => array(
+            ],
+        ],
+        'IMPORTDOC_CENTER_INACTIVE'               => [
             'type'      => Message::ERROR,
             'format'    => "Center '%%centerName%%' is marked as inactive. Please have an administrator activate this center if they are now an active team.",
-            'arguments' => array(
+            'arguments' => [
                 '%%centerName%%',
-            ),
-        ),
-        'IMPORTDOC_DATE_FORMAT_INCORRECT'         => array(
+            ],
+        ],
+        'IMPORTDOC_DATE_FORMAT_INCORRECT'         => [
             'type'      => Message::ERROR,
             'format'    => "Reporting date format was incorrect, '%%reportingDate%%'. Please input date explicitly (i.e. 'May 15, 2015').",
-            'arguments' => array(
+            'arguments' => [
                 '%%reportingDate%%',
-            ),
-        ),
-        'IMPORTDOC_DATE_NOT_FOUND'                => array(
+            ],
+        ],
+        'IMPORTDOC_DATE_NOT_FOUND'                => [
             'type'      => Message::ERROR,
             'format'    => "Could not find reporting date. Got '%%reportingDate%%'. The date format may be incorrect or this may be an invalid/corrupt sheet. Please input date explicitly (i.e. 'May 15, 2015').",
-            'arguments' => array(
+            'arguments' => [
                 '%%reportingDate%%',
-            ),
-        ),
-        'IMPORTDOC_VERSION_FORMAT_INCORRECT'      => array(
+            ],
+        ],
+        'IMPORTDOC_VERSION_FORMAT_INCORRECT'      => [
             'type'      => Message::ERROR,
             'format'    => "Version '%%version%%' is in an incorrect format. Sheet may be invalid/corrupt.",
-            'arguments' => array(
+            'arguments' => [
                 '%%version%%',
-            ),
-        ),
-        'IMPORTDOC_QUARTER_NOT_FOUND'             => array(
+            ],
+        ],
+        'IMPORTDOC_QUARTER_NOT_FOUND'             => [
             'type'      => Message::ERROR,
             'format'    => "Could not find quarter with date '%%reportingDate%%'. This may be an invalid/corrupt sheet",
-            'arguments' => array(
+            'arguments' => [
                 '%%reportingDate%%',
-            ),
-        ),
-        'IMPORTDOC_STATS_REPORT_LOCKED'           => array(
+            ],
+        ],
+        'IMPORTDOC_STATS_REPORT_LOCKED'           => [
             'type'      => Message::ERROR,
             'format'    => "Stats report for %%centerName%% on %%reportingDate%% is locked and cannot be overwritten.",
-            'arguments' => array(
+            'arguments' => [
                 '%%centerName%%',
                 '%%reportingDate%%',
-            ),
-        ),
+            ],
+        ],
 
         // CenterStats Importer Errors
-        'CENTERSTATS_WEEK_DATE_FORMAT_INVALID'    => array(
+        'CENTERSTATS_WEEK_DATE_FORMAT_INVALID'    => [
             'type'      => Message::ERROR,
             'format'    => "Week end date in column %%col%% is not in the correct format. The sheet may be corrupt.",
-            'arguments' => array(
+            'arguments' => [
                 '%%col%%',
-            ),
-        ),
+            ],
+        ],
 
         // Comm Course Importer Errors
-        'COMMCOURSE_START_DATE_FORMAT_INVALID'    => array(
+        'COMMCOURSE_START_DATE_FORMAT_INVALID'    => [
             'type'      => Message::ERROR,
             'format'    => "Start date format is invalid for %%type%% course.",
-            'arguments' => array(
+            'arguments' => [
                 '%%type%%',
-            ),
-        ),
-        'COMMCOURSE_START_DATE_FORMAT_UNREADABLE' => array(
+            ],
+        ],
+        'COMMCOURSE_START_DATE_FORMAT_UNREADABLE' => [
             'type'      => Message::ERROR,
             'format'    => "Unable to determine start date for %%type%% course due to invalid date format. Validation may be skipped. Check manually.",
-            'arguments' => array(
+            'arguments' => [
                 '%%type%%',
-            ),
-        ),
+            ],
+        ],
 
         // Contact Info Importer Errors
-        'CONTACTINFO_NO_NAME'                     => array(
-            'type'      => Message::WARNING,
-            'format'    => "No name provided for %%accountability%%.",
-            'arguments' => array(
+        'CONTACTINFO_NO_NAME'                     => [
+            'type'      => Message::ERROR,
+            'format'    => "No name provided for %%accountability%%. If your team does not have someone for this role, please put N/A in the name column.",
+            'arguments' => [
                 '%%accountability%%',
-            ),
-        ),
-        'CONTACTINFO_SLASHES_FOUND'               => array(
+            ],
+        ],
+        'CONTACTINFO_SLASHES_FOUND'               => [
             'type'      => Message::ERROR,
             'format'    => "Please provide name like 'Jane D' with a space, not a '/' separating the first name and last initial.",
-            'arguments' => array(),
-        ),
+            'arguments' => [],
+        ],
+        'CONTACTINFO_NO_MATCHING_TEAM_MEMBER'     => [
+            'type'      => Message::WARNING,
+            'format'    => "Unable to find a team member with the name %%name%% on the Class List for %%accountability%%. Please make sure the first name and last initial match the team member exactly.",
+            'arguments' => [
+                '%%name%%',
+                '%%accountability%%',
+            ],
+        ],
 
 
         // '' => array(
@@ -713,7 +744,7 @@ class Message
         //     'arguments' => array(
         //     ),
         // ),
-    );
+    ];
 
     protected $section = '';
 
@@ -721,6 +752,7 @@ class Message
     {
         $me = new static();
         $me->section = $section;
+
         return $me;
     }
 
@@ -729,12 +761,12 @@ class Message
         $message = static::$messageList[$messageId];
         $arguments = array_slice(func_get_args(), 2);
 
-        $result = array(
+        $result = [
             'id'      => $messageId,
             'type'    => $this->getMessageTypeString($message['type']),
             'section' => $this->section,
             'message' => $this->getMessageFromFormat($messageId, $message['format'], $message['arguments'], $arguments),
-        );
+        ];
 
         if ($offset !== null) {
             $result['offset'] = $offset;
@@ -744,7 +776,7 @@ class Message
         return $result;
     }
 
-    protected function getMessageFromFormat($messageId, $format, $argumentNames, $arguments = array())
+    protected function getMessageFromFormat($messageId, $format, $argumentNames, $arguments = [])
     {
         if (count($argumentNames) != count($arguments)) {
             throw new \Exception("Argument name and value counts do not match for '$messageId'");

--- a/src/app/TeamMember.php
+++ b/src/app/TeamMember.php
@@ -27,6 +27,7 @@ class TeamMember extends Model
             case 'firstName':
             case 'lastName':
             case 'center':
+            case 'accountabilities':
                 return $this->person->$name;
             case 'quarterNumber':
                 return static::getQuarterNumber($this->incomingQuarter, $this->person->center->region);

--- a/src/app/Util.php
+++ b/src/app/Util.php
@@ -105,6 +105,17 @@ class Util
         return static::$reportDate ?: Carbon::now()->startOfDay();
     }
 
+    public static function now($includeTime = false)
+    {
+        $date = static::getReportDate();
+
+        if ($includeTime && $date->eq(Carbon::now()->startOfDay())) {
+            $date = Carbon::now();
+        }
+
+        return $date;
+    }
+
     public static function getNameParts($name)
     {
         $parts = array(
@@ -117,10 +128,19 @@ class Util
         }
 
         $names = explode(' ', trim($name));
-        if ($names && count($names) > 0) {
-            $parts['firstName'] = $names[0];
-            if (count($names) > 1) {
-                $parts['lastName'] = trim(str_replace('.', '', $names[1]));
+
+        $partsCount = count($names);
+        if ($names && $partsCount > 0) {
+            // For names Like 'Mary Louise C'
+            if ($partsCount > 2) {
+                $parts['firstName'] = implode(' ', array_slice($names, 0, -1));
+                $parts['firstName'] = trim($parts['firstName']);
+                $parts['lastName'] = trim(str_replace('.', '', $names[$partsCount - 1]));
+            } else {
+                $parts['firstName'] = trim($names[0]);
+                if ($partsCount > 1) {
+                    $parts['lastName'] = trim(str_replace('.', '', $names[1]));
+                }
             }
         }
         return $parts;

--- a/src/app/Validate/Objects/ContactInfoValidator.php
+++ b/src/app/Validate/Objects/ContactInfoValidator.php
@@ -26,6 +26,7 @@ class ContactInfoValidator extends ObjectsValidatorAbstract
         if ($data->accountability == 'Reporting Statistician') {
             $emailValidator = v::alwaysValid();
         } else if (preg_match('/^N\/?A$/i', $data->name)) {
+            $this->skipped = true;
             return; // Skip rows with names == NA or N/A
         }
 
@@ -37,6 +38,27 @@ class ContactInfoValidator extends ObjectsValidatorAbstract
 
     protected function validate($data)
     {
+        if (!$this->validateName($data)) {
+            $this->isValid = false;
+        }
+
         return $this->isValid;
+    }
+
+    protected function validateName($data)
+    {
+        $isValid = true;
+
+        if (strpos($data->name, '/') !== false) {
+            $this->addMessage('CONTACTINFO_SLASHES_FOUND');
+            $isValid = false;
+        }
+
+        if (strtolower($data->name) == 'not applicable' || !$data->name) {
+            $this->addMessage('CONTACTINFO_NO_NAME', $data->accountability);
+            $isValid = false;
+        }
+
+        return $isValid;
     }
 }

--- a/src/app/Validate/Objects/ObjectsValidatorAbstract.php
+++ b/src/app/Validate/Objects/ObjectsValidatorAbstract.php
@@ -11,11 +11,17 @@ abstract class ObjectsValidatorAbstract extends ValidatorAbstract
 {
     protected $dataValidators = array();
     protected $reader = null;
+    protected $skipped = false;
 
-    public function run($data)
+    public function run($data, $supplementalData = null)
     {
         $this->data = $data;
+        $this->supplementalData = $supplementalData;
         $this->populateValidators($data);
+
+        if ($this->skipped) {
+            return $this->isValid;
+        }
 
         foreach ($this->dataValidators as $field => $validator)
         {

--- a/src/app/Validate/Relationships/CommittedTeamMemberValidator.php
+++ b/src/app/Validate/Relationships/CommittedTeamMemberValidator.php
@@ -1,0 +1,29 @@
+<?php
+namespace TmlpStats\Validate\Relationships;
+
+use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
+use TmlpStats\Util;
+use TmlpStats\Validate\ValidatorAbstract;
+
+class CommittedTeamMemberValidator extends ValidatorAbstract
+{
+    protected $sheetId = ImportDocument::TAB_WEEKLY_STATS;
+
+    protected function validate($data)
+    {
+        if (!$data->committedTeamMemberName) {
+            return $this->isValid;
+        }
+
+        $nameParts = Util::getNameParts($data->committedTeamMemberName);
+
+        $first = strtolower($nameParts['firstName']);
+        $last = strtolower($nameParts['lastName']);
+
+        if (!isset($this->supplementalData['names'][$first][$last])) {
+            $this->addMessage('TMLPREG_COMMITTED_TEAM_MEMBER_NO_MATCHING_TEAM_MEMBER', $data->committedTeamMemberName);
+        }
+
+        return $this->isValid;
+    }
+}

--- a/src/app/Validate/Relationships/ContactInfoTeamMemberValidator.php
+++ b/src/app/Validate/Relationships/ContactInfoTeamMemberValidator.php
@@ -1,0 +1,34 @@
+<?php
+namespace TmlpStats\Validate\Relationships;
+
+use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
+use TmlpStats\Util;
+use TmlpStats\Validate\ValidatorAbstract;
+
+class ContactInfoTeamMemberValidator extends ValidatorAbstract
+{
+    protected $sheetId = ImportDocument::TAB_LOCAL_TEAM_CONTACT;
+
+    protected function validate($data)
+    {
+        if ($data->accountability == 'Program Manager'
+            || $data->accountability == 'Classroom Leader'
+            || !$data->name
+            || $data->name == 'NA'
+            || $data->name == 'N/A'
+        ) {
+            return $this->isValid;
+        }
+
+        $nameParts = Util::getNameParts($data->name);
+
+        $first = strtolower($nameParts['firstName']);
+        $last = strtolower($nameParts['lastName']);
+
+        if (!isset($this->supplementalData['names'][$first][$last])) {
+            $this->addMessage('CONTACTINFO_NO_MATCHING_TEAM_MEMBER', $data->name, $data->accountability);
+        }
+
+        return $this->isValid;
+    }
+}

--- a/src/app/Validate/Relationships/DuplicateTeamMemberValidator.php
+++ b/src/app/Validate/Relationships/DuplicateTeamMemberValidator.php
@@ -1,0 +1,39 @@
+<?php
+namespace TmlpStats\Validate\Relationships;
+
+use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
+use TmlpStats\Validate\ValidatorAbstract;
+
+class DuplicateTeamMemberValidator extends ValidatorAbstract
+{
+    protected $sheetId = ImportDocument::TAB_CLASS_LIST;
+
+    protected static $names = [];
+
+    protected function validate($data)
+    {
+        $first = trim(str_replace('.', '', strtolower($data->firstName)));
+        $last = trim(str_replace('.', '', strtolower($data->lastName)));
+
+        if (isset(static::$names[$first][$last])) {
+            if (static::$names[$first][$last]) {
+                $this->addMessage('CLASSLIST_DUPLICATE_TEAM_MEMBER', $data->firstName, $data->lastName);
+                $this->isValid = false;
+            }
+        }
+
+        static::$names[$first][$last][] = $data;
+
+        return $this->isValid;
+    }
+
+    public function getWorkingData()
+    {
+        return ['names' => static::$names];
+    }
+
+    public function resetWorkingData()
+    {
+        static::$names = [];
+    }
+}

--- a/src/app/Validate/Relationships/DuplicateTeamMemberValidator.php
+++ b/src/app/Validate/Relationships/DuplicateTeamMemberValidator.php
@@ -12,7 +12,7 @@ class DuplicateTeamMemberValidator extends ValidatorAbstract
 
     protected function validate($data)
     {
-        $first = trim(str_replace('.', '', strtolower($data->firstName)));
+        $first = strtolower($data->firstName);
         $last = trim(str_replace('.', '', strtolower($data->lastName)));
 
         if (isset(static::$names[$first][$last])) {

--- a/src/app/Validate/Relationships/DuplicateTmlpRegistrationValidator.php
+++ b/src/app/Validate/Relationships/DuplicateTmlpRegistrationValidator.php
@@ -12,7 +12,7 @@ class DuplicateTmlpRegistrationValidator extends ValidatorAbstract
 
     protected function validate($data)
     {
-        $first = trim(str_replace('.', '', strtolower($data->firstName)));
+        $first = strtolower($data->firstName);
         $last = trim(str_replace('.', '', strtolower($data->lastName)));
 
         if (isset(static::$names[$first][$last]) ) {

--- a/src/app/Validate/Relationships/DuplicateTmlpRegistrationValidator.php
+++ b/src/app/Validate/Relationships/DuplicateTmlpRegistrationValidator.php
@@ -1,0 +1,41 @@
+<?php
+namespace TmlpStats\Validate\Relationships;
+
+use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
+use TmlpStats\Validate\ValidatorAbstract;
+
+class DuplicateTmlpRegistrationValidator extends ValidatorAbstract
+{
+    protected $sheetId = ImportDocument::TAB_WEEKLY_STATS;
+
+    protected static $names = [];
+
+    protected function validate($data)
+    {
+        $first = trim(str_replace('.', '', strtolower($data->firstName)));
+        $last = trim(str_replace('.', '', strtolower($data->lastName)));
+
+        if (isset(static::$names[$first][$last]) ) {
+            if (static::$names[$first][$last]) {
+                $this->addMessage('TMLPREG_DUPLICATE_NAME', $data->firstName, $data->lastName);
+                $this->isValid = false;
+            }
+        }
+
+        if (!$data->wd) {
+            static::$names[$first][$last][] = $data;
+        }
+
+        return $this->isValid;
+    }
+
+    public function getWorkingData()
+    {
+        return ['names' => static::$names];
+    }
+
+    public function resetWorkingData()
+    {
+        static::$names = [];
+    }
+}

--- a/src/app/Validate/ValidationManager.php
+++ b/src/app/Validate/ValidationManager.php
@@ -15,6 +15,8 @@ class ValidationManager
 
     protected $messages = [];
 
+    protected $workspace = [];
+
     public function __construct(&$statsReport)
     {
         $this->statsReport = $statsReport;
@@ -24,33 +26,70 @@ class ValidationManager
     {
         $isValid = true;
 
-        foreach ($data as $type => &$list) {
+        foreach (array_keys($data) as $type) {
 
             if ($type == 'expectedVersion' || $type == 'expectedDate') {
                 continue;
             }
 
-            foreach ($list as &$dataArray) {
-                $dataObj = Util::arrayToObject($dataArray);
-                $validator = ValidatorFactory::build($this->statsReport, $type);
-                if (!$validator->run($dataObj)) {
-                    $isValid = false;
-                    foreach ($validator->getMessages() as $message) {
-                        if (isset($message['offset'])) {
-                            $dataArray['errors'][] = $message;
-                        }
-                    }
-                }
-                $this->mergeMessages($validator->getMessages());
+            if (!$this->processDataList($type, $data[$type])) {
+                $isValid = false;
+            }
+        }
+
+        $duplicateChecks = [
+            'duplicateTeamMember'       => 'classList',
+            'duplicateTmlpRegistration' => 'tmlpRegistration',
+        ];
+        foreach ($duplicateChecks as $type => $key) {
+            if (!$this->processDataList($type, $data[$key])) {
+                $isValid = false;
+            }
+        }
+
+        // These need needs the class list to
+        $teamMemberExistsChecks = [
+            'contactInfoTeamMember' => 'contactInfo',
+            'committedTeamMember'   => 'tmlpRegistration',
+        ];
+        foreach ($teamMemberExistsChecks as $type => $key) {
+            if (!$this->processDataList($type, $data[$key], $this->workspace['duplicateTeamMember'])) {
+                $isValid = false;
             }
         }
 
         foreach (['teamExpansion', 'centerGames', 'statsReport'] as $type) {
-
             $validator = ValidatorFactory::build($this->statsReport, $type);
             if (!$validator->run($data)) {
                 $isValid = false;
             }
+            $this->mergeMessages($validator->getMessages());
+        }
+
+        $this->resetValidators();
+
+        return $isValid;
+    }
+
+    public function processDataList($type, &$list, $supplementalData = null)
+    {
+        if (!isset($this->workspace[$type])) {
+            $this->workspace[$type] = [];
+        }
+
+        $isValid = true;
+        foreach ($list as &$dataArray) {
+            $dataObj = Util::arrayToObject($dataArray);
+            $validator = ValidatorFactory::build($this->statsReport, $type);
+            if (!$validator->run($dataObj, $supplementalData)) {
+                $isValid = false;
+                foreach ($validator->getMessages() as $message) {
+                    if (isset($message['offset'])) {
+                        $dataArray['errors'][] = $message;
+                    }
+                }
+            }
+            $this->updateWorkspace($type, $validator->getWorkingData());
             $this->mergeMessages($validator->getMessages());
         }
 
@@ -65,6 +104,26 @@ class ValidationManager
     protected function mergeMessages($messages)
     {
         $this->messages = array_merge($this->messages, $messages);
+    }
+
+    protected function updateWorkspace($type, $workspace)
+    {
+        $this->workspace[$type] = array_merge($this->workspace[$type], $workspace);
+    }
+
+    /**
+     * Reset the working data for all validators that reported it.
+     *
+     * @throws \Exception
+     */
+    protected function resetValidators()
+    {
+        foreach ($this->workspace as $type => $data) {
+            if ($data) {
+                $validator = ValidatorFactory::build($this->statsReport, $type);
+                $validator->resetWorkingData();
+            }
+        }
     }
 }
 

--- a/src/app/Validate/ValidatorAbstract.php
+++ b/src/app/Validate/ValidatorAbstract.php
@@ -10,6 +10,7 @@ abstract class ValidatorAbstract
 
     protected $isValid = true;
     protected $data = null;
+    protected $supplementalData = null;
     protected $statsReport = null;
 
     protected $messages = array();
@@ -31,9 +32,10 @@ abstract class ValidatorAbstract
         }
     }
 
-    public function run($data)
+    public function run($data, $supplementalData = null)
     {
         $this->data = $data;
+        $this->supplementalData = $supplementalData;
 
         $this->validate($data);
 
@@ -43,6 +45,27 @@ abstract class ValidatorAbstract
     public function getMessages()
     {
         return $this->messages;
+    }
+
+    /**
+     * Returns any working data that may be useful to other validators. This is helpful when checking
+     * relationships between data types and you've already done some preprocessing.
+     *
+     * @return array
+     */
+    public function getWorkingData()
+    {
+        return [];
+    }
+
+    /**
+     * Since sometime the working data is managed as static variables, we will call this method after the
+     * validation manager completes to cleanup any working data.
+     *
+     */
+    public function resetWorkingData()
+    {
+        // noop
     }
 
     abstract protected function validate($data);

--- a/src/app/Validate/ValidatorFactory.php
+++ b/src/app/Validate/ValidatorFactory.php
@@ -21,6 +21,10 @@ class ValidatorFactory
             case 'statsReport':
                 $class = '\\TmlpStats\\Validate\\Objects\\' . ucfirst($type) . 'Validator';
                 break;
+            case 'committedTeamMember':
+            case 'contactInfoTeamMember':
+            case 'duplicateTeamMember':
+            case 'duplicateTmlpRegistration':
             case 'teamExpansion':
             case 'centerGames':
                 $class = '\\TmlpStats\\Validate\\Relationships\\' . ucfirst($type) . 'Validator';

--- a/src/database/migrations/2015_11_22_232205_add_starts_ends_to_accountability_person_table.php
+++ b/src/database/migrations/2015_11_22_232205_add_starts_ends_to_accountability_person_table.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+use Carbon\Carbon;
+use TmlpStats\Accountability;
+
+class AddStartsEndsToAccountabilityPersonTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accountability_person', function (Blueprint $table) {
+            $table->timestamp('starts_at')->default(DB::raw('CURRENT_TIMESTAMP'))->after('accountability_id');
+            $table->timestamp('ends_at')->nullable()->default(null)->after('starts_at');
+        });
+
+        DB::table('accountability_person')
+            ->update(['starts_at' => Carbon::now()->subWeeks(13)]);
+
+        DB::table('accountability_person')
+            ->where('active', false)
+            ->update(['ends_at' => Carbon::now()->subWeeks(13)]);
+
+        $accountabilities = Accountability::all();
+        foreach ($accountabilities as $accountability) {
+            switch ($accountability->name) {
+                case 'teamStatistician':
+                    $accountability->name = 'statistician';
+                    $accountability->save();
+                    break;
+                case 'teamStatisticianApprentice':
+                    $accountability->name = 'statisticianApprentice';
+                    $accountability->save();
+                    break;
+                case 'team1TeamLeader':
+                    $accountability->name = 't1tl';
+                    $accountability->save();
+                    break;
+                case 'team2TeamLeader':
+                    $accountability->name = 't2tl';
+                    $accountability->save();
+                    break;
+                default:
+                    continue;
+            }
+        }
+
+        Schema::table('accountability_person', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('accountability_person', function (Blueprint $table) {
+            $table->boolean('active')->default(true)->after('accountability_id');
+
+            DB::table('accountability_person')
+                ->where('ends_at', '<', Carbon::now())
+                ->update(['active' => false]);
+
+            $table->dropColumn('starts_at');
+            $table->dropColumn('ends_at');
+        });
+    }
+}

--- a/src/resources/views/statsreports/details/classlist.blade.php
+++ b/src/resources/views/statsreports/details/classlist.blade.php
@@ -30,7 +30,7 @@
                             <td>{{ $memberData->lastName }}</td>
                             <td style="text-align: center">{{ $quarterNumber }}</td>
                             <td><?php
-                                $accountabilities = $memberData->teamMember->person->accountabilities()->get();
+                                $accountabilities = $memberData->teamMember->accountabilities;
 
                                 if ($accountabilities) {
                                     $accountabilityNames = array();


### PR DESCRIPTION
This required a lot of changes to the importing and validation of people.
- Added new fields starts_at and ends_at to accountability_person table to track when they held the accountability
- Added relationship validators to check that committed team members and contact info accountables exist on class list
- Added relationship validators to check for duplicate team member names and require they get distinguished
- Added a new console command to merge duplicate people.
- Various improvements in how we import and distinguish people.