### PR TITLE
Fix accountability expiration.

### DIFF
--- a/src/app/Person.php
+++ b/src/app/Person.php
@@ -132,7 +132,7 @@ class Person extends Model
             DB::table('accountability_person')
                 ->where('person_id', $this->id)
                 ->where('accountability_id', $accountability->id)
-                ->update(['ends_at' => Util::now()]);
+                ->update(['ends_at' => Util::now()->copy()->subSecond()]);
         }
     }
 


### PR DESCRIPTION
Accountabilities were expiring now(), meaning at 0:00:00 today. New accountables
also started now(). Checks for the current accountable looked for

now() >= start and now() < end

Since the accountables started and ended at the same time, they both matched and
the old accountable ended up getting the emails.