### PR TITLE
Make Travel/Room deadline configurable

### DIFF
--- a/src/app/Message.php
+++ b/src/app/Message.php
@@ -309,11 +309,6 @@ class Message
             'format'    => "Rooming is not booked. Make sure the comment provides a specific promise for when rooming will be complete.",
             'arguments' => [],
         ],
-        'TMLPREG_TRAVEL_ROOM_CTW_COMMENT_REVIEW'                        => [
-            'type'      => Message::WARNING,
-            'format'    => "Travel/rooming are not complete by 2 weeks before the end of the quarter. Make sure the comment states that they are in a Conversation To Withdraw (CTW).",
-            'arguments' => [],
-        ],
         'TMLPREG_DUPLICATE_NAME'                                        => [
             'type'      => Message::ERROR,
             'format'    => "There are multiple registrations with the name '%%firstName%% %%lastName%%'. You may have accidentally added them twice. If you have 2 people with the same first name and last initial, please provide an additional letter of their last name so we can tell them apart. Make sure to use the same spelling if you reference them on other tabs.",
@@ -525,11 +520,6 @@ class Message
         'CLASSLIST_ROOM_COMMENT_REVIEW'                                 => [
             'type'      => Message::WARNING,
             'format'    => "Rooming is not booked. Make sure the comment provides a specific promise for when rooming will be complete.",
-            'arguments' => [],
-        ],
-        'CLASSLIST_TRAVEL_ROOM_CTW_MISSING'                             => [
-            'type'      => Message::ERROR,
-            'format'    => "If travel and rooming are not complete by 2 weeks before the end of the quarter, mark the team member as a Conversation To Withdraw (CTW).",
             'arguments' => [],
         ],
         'CLASSLIST_DUPLICATE_TEAM_MEMBER'                               => [

--- a/src/app/Traits/ValidatesTravelWithConfig.php
+++ b/src/app/Traits/ValidatesTravelWithConfig.php
@@ -1,0 +1,31 @@
+<?php
+namespace TmlpStats\Traits;
+
+use Carbon\Carbon;
+use TmlpStats\Setting;
+
+trait ValidatesTravelWithConfig
+{
+    public function isTimeToCheckTravel()
+    {
+        $classroomNames = [
+            'classroom1Date',
+            'classroom2Date',
+            'classroom3Date',
+        ];
+
+        $travelDueSetting = Setting::get('travelDueByDate', $this->statsReport->center);
+
+        $dueDate = $this->statsReport->quarter->classroom2Date;
+        if ($travelDueSetting) {
+            $settingValue = $travelDueSetting->value;
+            if (in_array($settingValue, $classroomNames)) {
+                $dueDate = $this->statsReport->quarter->$settingValue;
+            } else if (preg_match('/^\d\d\d\d-\d\d-\d\d$/', $settingValue)) {
+                $dueDate = Carbon::parse($settingValue);
+            }
+        }
+
+        return $this->statsReport->reportingDate->gt($dueDate);
+    }
+}

--- a/src/app/Validate/Objects/ClassListValidator.php
+++ b/src/app/Validate/Objects/ClassListValidator.php
@@ -3,9 +3,12 @@ namespace TmlpStats\Validate\Objects;
 
 use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
 use Respect\Validation\Validator as v;
+use TmlpStats\Traits\ValidatesTravelWithConfig;
 
 class ClassListValidator extends ObjectsValidatorAbstract
 {
+    use ValidatesTravelWithConfig;
+
     protected $sheetId = ImportDocument::TAB_CLASS_LIST;
 
     protected function populateValidators($data)
@@ -210,8 +213,8 @@ class ClassListValidator extends ObjectsValidatorAbstract
             return $isValid; // Not required if withdrawn
         }
 
-        // Travel and Rooming must be reported starting after the 2nd Classroom
-        if ($this->statsReport->reportingDate->gt($this->statsReport->quarter->classroom1Date)) {
+        // Travel and Rooming must be reported starting after the configured date
+        if ($this->isTimeToCheckTravel()) {
             if (is_null($data->travel)) {
                 // Error if no comment provided, warning to look at it otherwise
                 if (is_null($data->comment)) {
@@ -229,19 +232,6 @@ class ClassListValidator extends ObjectsValidatorAbstract
                 } else {
                     $this->addMessage('CLASSLIST_ROOM_COMMENT_REVIEW');                }
             }
-
-            // Disabling check 08/15. Ending this practice
-            //
-            // Any team member without travel AND rooming booked by 2 weeks before the end of the quarter
-            // is considered in a Conversation To Withdraw
-            // $endDate = clone $this->statsReport->quarter->endWeekendDate;
-            // $twoWeeksBeforeWeekend = $endDate->subWeeks(2);
-            // if ($this->statsReport->reportingDate->gte($twoWeeksBeforeWeekend)) {
-            //     if ((is_null($data->travel) || is_null($data->room)) && is_null($data->ctw)) {
-            //         $this->addMessage('CLASSLIST_TRAVEL_ROOM_CTW_MISSING');
-            //         $isValid = false;
-            //     }
-            // }
         }
 
         return $isValid;

--- a/src/app/Validate/Objects/TmlpRegistrationValidator.php
+++ b/src/app/Validate/Objects/TmlpRegistrationValidator.php
@@ -3,9 +3,12 @@ namespace TmlpStats\Validate\Objects;
 
 use TmlpStats\Import\Xlsx\ImportDocument\ImportDocument;
 use Respect\Validation\Validator as v;
+use TmlpStats\Traits\ValidatesTravelWithConfig;
 
 class TmlpRegistrationValidator extends ObjectsValidatorAbstract
 {
+    use ValidatesTravelWithConfig;
+
     const MAX_DAYS_TO_SEND_APPLICATION_OUT = 2;
     const MAX_DAYS_TO_APPROVE_APPLICATION = 14;
 
@@ -368,7 +371,8 @@ class TmlpRegistrationValidator extends ObjectsValidatorAbstract
             return $isValid; // Not required if withdrawn or future registration
         }
 
-        if ($this->statsReport->reportingDate->gt($this->statsReport->quarter->classroom1Date)) {
+        // Travel and Rooming must be reported starting after the configured date
+        if ($this->isTimeToCheckTravel()) {
             if (is_null($data->travel)) {
                 // Error if no comment provided, warning to look at it otherwise
                 if (is_null($data->comment)) {
@@ -387,17 +391,6 @@ class TmlpRegistrationValidator extends ObjectsValidatorAbstract
                     $this->addMessage('TMLPREG_ROOM_COMMENT_REVIEW');
                 }
             }
-
-            // Disabling check 08/15. Ending this practice
-            //
-            // Any approved incoming without travel AND rooming booked by 2 weeks before the end of the quarter
-            // is considered in a Conversation To Withdraw
-            // $twoWeeksBeforeWeekend = $this->statsReport->quarter->endWeekendDate->subWeeks(2);
-            // if ($this->statsReport->reportingDate->gte($twoWeeksBeforeWeekend) && !is_null($data->appr)) {
-            //     if (is_null($data->travel) || is_null($data->room)) {
-            //         $this->addMessage('TMLPREG_TRAVEL_ROOM_CTW_COMMENT_REVIEW');
-            //     }
-            // }
         }
 
         return $isValid;


### PR DESCRIPTION
Added a new setting for travelDueByDate after which the validator travel/rooming messages appear
Settings can be date values (YYYY-MM-DD), or the classroom field names:
- classroom1Date
- classroom2Date
- classroom3Date