### PR TITLE
Fix localized dates

### DIFF
--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -35,9 +35,9 @@ class AppServiceProvider extends ServiceProvider
         );
 
         Blade::directive('date', function($expression) {
-            $format = Util::getLocaleDateFormat();
+            $php = "<?php echo with{$expression}->toDateString(); ?>";
 
-            return "<?php echo with{$expression}->format('{$format}'); ?>";
+            return "<span class='date' data-date='{$php}'></span>";
         });
 
         Blade::directive('statsReportLink', function($expression) {

--- a/src/resources/views/globalreports/show.blade.php
+++ b/src/resources/views/globalreports/show.blade.php
@@ -139,6 +139,14 @@
             return message;
         }
 
+        function updateDates() {
+            $('span.date').each(function (index, dateElem) {
+                var formatted = moment($(dateElem).data('date')).format('l');
+                formatted = formatted.replace(/\d\d(\d\d)/, "$1");
+                $(dateElem).text(formatted);
+            });
+        }
+
         var pages = [
             'ratingsummary',
             'regionalstats',
@@ -209,6 +217,7 @@
 
                 $.get(url, function (response) {
                     $(container).html(response);
+                    updateDates();
                 }).fail(function (jqXHR) {
                     var message = getErrorMessage(jqXHR.status);
                     $(container).html('<br/><p>' + message + '</p>');
@@ -226,6 +235,7 @@
                 $.get(url, function (response) {
                     $.each(response, function (name, data) {
                         $("#" + name + "-container").html(data);
+                        updateDates();
                     });
                 }).fail(function (jqXHR) {
                     var message = getErrorMessage(jqXHR.status);

--- a/src/resources/views/template.blade.php
+++ b/src/resources/views/template.blade.php
@@ -36,6 +36,7 @@
     <script src="{{ asset('/components/datatables.net/js/jquery.dataTables.min.js') }}" type="text/javascript"></script>
     <script src="{{ asset('/components/datatables.net-bs/js/dataTables.bootstrap.min.js') }}" type="text/javascript"></script>
     <script src="{{ asset('/components/jquery-loading/dist/jquery.loading.min.js') }}" type="text/javascript"></script>
+    <script src="{{ asset('/components/moment/min/moment-with-locales.min.js') }}" type="text/javascript"></script>
     <script src="{{ asset('/components/jstz/jstz.min.js') }}" type="text/javascript"></script>
 
     @if (!Session::has('timezone') || !Session::has('locale'))


### PR DESCRIPTION
The previous attempt to localize dates broken because of the way caching
is handled. This new method uses moment.js to generate the localized
version of the date.