### PR TITLE
Add configurable stats Due datetime and respond by datetime settings

### DIFF
--- a/src/app/ModelCache.php
+++ b/src/app/ModelCache.php
@@ -1,15 +1,38 @@
 <?php
 namespace TmlpStats;
 
+/**
+ * Class ModelCache
+ * @package TmlpStats
+ *
+ * Maintain an in memory object cache.
+ * Simplifies reusing objects and relationships across a single transaction
+ *
+ */
 class ModelCache
 {
     protected static $modelCache = [];
 
+    /**
+     * Get class instance (easy chaining)
+     * e.g.
+     *    ModelCache::create()->get('key', 132);
+     *
+     * @return static
+     */
     public static function create()
     {
         return new static();
     }
 
+    /**
+     * Get an object from the cache
+     *
+     * @param $key Object Key Name
+     * @param $id  Object Id
+     *
+     * @return null|object Object from cache
+     */
     public function get($key, $id)
     {
         return isset(static::$modelCache[$key][$id])
@@ -17,11 +40,24 @@ class ModelCache
             : null;
     }
 
+    /**
+     * Add an object to the cache
+     *
+     * @param $key   Object Key Name
+     * @param $id    Object id
+     * @param $value New object to save
+     */
     public function set($key, $id, $value)
     {
         static::$modelCache[$key][$id] = $value;
     }
 
+    /**
+     * Remove an object from the cache
+     *
+     * @param      $key Object Key Name
+     * @param null $id  Object id, or null to remove all of this type
+     */
     public function forget($key, $id = null)
     {
         if ($id !== null) {
@@ -31,8 +67,11 @@ class ModelCache
         }
     }
 
+    /**
+     * Clear the entire cache
+     */
     public function flush()
     {
-        static::$modelCache = null;
+        static::$modelCache = [];
     }
 }

--- a/src/app/Util.php
+++ b/src/app/Util.php
@@ -2,19 +2,34 @@
 namespace TmlpStats;
 
 use Cache;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
 use Exception;
-use Carbon\Carbon;
 use Session;
+use stdClass;
 
 class Util
 {
+    /**
+     * Convert camelCase string to lowercase words
+     *
+     * @param $str
+     *
+     * @return string
+     */
     public static function toWords($str)
     {
         $output = preg_replace("/([A-Z])/", " $1", $str);
         return strtolower($output);
     }
 
+    /**
+     * Convert snake_case string to camelCase
+     *
+     * @param $str
+     *
+     * @return mixed
+     */
     public static function camelCase($str)
     {
         $parts = explode('_', $str);
@@ -29,9 +44,16 @@ class Util
         return $output ?: $str;
     }
 
+    /**
+     * Convert an associative array to an object using the camelCase version of the keys as properties
+     *
+     * @param $array
+     *
+     * @return stdClass
+     */
     public static function arrayToObject($array)
     {
-        $object = new \stdClass;
+        $object = new stdClass;
 
         foreach ($array as $key => $value) {
 
@@ -42,9 +64,16 @@ class Util
         return $object;
     }
 
+    /**
+     * Convert an object with snake_case properties to an object with camelCase properties
+     *
+     * @param $object
+     *
+     * @return stdClass
+     */
     public static function objectToCamelCase($object)
     {
-        $new = new \stdClass;
+        $new = new stdClass;
         $properties = get_object_vars($object);
 
         foreach ($properties as $key => $value) {
@@ -55,6 +84,13 @@ class Util
         return $new;
     }
 
+    /**
+     * Convert an Excel date integer into a Carbon datetime object
+     *
+     * @param $excelDate
+     *
+     * @return bool|Carbon
+     */
     public static function getExcelDate($excelDate)
     {
         $dateObj = null;
@@ -67,6 +103,13 @@ class Util
         return $dateObj ? $dateObj->startOfDay() : false;
     }
 
+    /**
+     * Convert a string with an unknown date format into a Carbon datetime object
+     *
+     * @param $dateStr
+     *
+     * @return null|static
+     */
     public static function parseUnknownDateFormat($dateStr)
     {
         $dateObj = null;
@@ -96,17 +139,40 @@ class Util
         return $dateObj ? $dateObj->startOfDay() : null;
     }
 
+    /**
+     * Assumed report date
+     *
+     * @var null|Carbon
+     */
     protected static $reportDate = null;
+
+    /**
+     * Set the report date
+     *
+     * @param Carbon $date
+     */
     public static function setReportDate(Carbon $date)
     {
         static::$reportDate = $date;
     }
 
+    /**
+     * Get the previously set report date, or today
+     *
+     * @return Carbon
+     */
     public static function getReportDate()
     {
         return static::$reportDate ?: Carbon::now()->startOfDay();
     }
 
+    /**
+     * Alias for getReportDate() except you can optionally include the current time
+     *
+     * @param bool|false $includeTime
+     *
+     * @return Carbon|static
+     */
     public static function now($includeTime = false)
     {
         $date = static::getReportDate();
@@ -118,6 +184,13 @@ class Util
         return $date;
     }
 
+    /**
+     * Split a name string into firstName and lastName parts
+     *
+     * @param $name
+     *
+     * @return array
+     */
     public static function getNameParts($name)
     {
         $parts = array(
@@ -205,6 +278,14 @@ class Util
         return substr(strrchr(get_class($object), '\\'), 1);
     }
 
+    /**
+     * Get the date formatted using the locale
+     * e.g.
+     *      en-US => 12/25/2015
+     *      en-UK => 25/12/2015
+     *
+     * @return string
+     */
     public static function getLocaleDateFormat()
     {
         $format = 'M j, Y';

--- a/src/resources/views/emails/statssubmitted.blade.php
+++ b/src/resources/views/emails/statssubmitted.blade.php
@@ -3,10 +3,10 @@ Hi {{ $user }},<br/>
 Thank you for submitting stats for team {{ $centerName }}.
 
 @if ($isLate)
-Your stats are late. They were due on {{ $due }}.
+Your stats are late. They were due on {{ $due->format('l, F jS \a\t g:ia') }}.
 @endif
 
-We received them on {{ $time }} your local time. Please find the submitted sheet attached.<br/>
+We received them on {{ $submittedAt->format('l, F jS \a\t g:ia') }} your local time. Please find the submitted sheet attached.<br/>
 <br/>
 
 @if (isset($sheet['errors']) && $sheet['errors'])
@@ -14,7 +14,7 @@ We received them on {{ $time }} your local time. Please find the submitted sheet
     <br/>
 @endif
 
-You are not complete yet. Your regional statistician will review your sheet and declare you complete by {{ $respondByTime }} your local time Saturday morning.<br/>
+You are not complete yet. Your regional statistician will review your sheet and declare you complete by {{ $respondByDateTime->format('l \a\t g:ia') }} your local time.<br/>
 <br/>
 
 @if ($reportUrl)

--- a/src/tests/unit/Import/ImportManagerTest.php
+++ b/src/tests/unit/Import/ImportManagerTest.php
@@ -1,0 +1,231 @@
+<?php
+namespace TmlpStats\Tests;
+
+use Carbon\Carbon;
+use stdClass;
+use TmlpStats\Center;
+use TmlpStats\Import\ImportManager;
+use TmlpStats\Tests\Traits\MocksSettings;
+
+class ImportManagerTest extends TestAbstract
+{
+    use MocksSettings;
+
+    protected $testClass = ImportManager::class;
+
+    /**
+     * @dataProvider providerGetStatsDueDateTime
+     */
+    public function testGetStatsDueDateTime($statsReport, $reportingDate, $settingData, $expectedResponse)
+    {
+        $this->unsetSetting('centerReportDue');
+        if ($settingData !== null) {
+            $this->setSetting('centerReportDue', json_encode($settingData));
+        }
+
+        $statsReport->reportingDate = $reportingDate;
+
+        $result = ImportManager::getStatsDueDateTime($statsReport);
+
+        $this->assertInstanceOf(Carbon::class, $result);
+        $this->assertTrue($expectedResponse->eq($result));
+    }
+
+    public function providerGetStatsDueDateTime()
+    {
+        $timezone = 'America/Vancouver';
+
+        $statsReport                   = new stdClass;
+        $statsReport->center           = new Center();
+        $statsReport->center->id       = 0;
+        $statsReport->center->timezone = $timezone;
+
+        $statsReport->quarter                   = new stdClass;
+        $statsReport->quarter->startWeekendDate = Carbon::create(2015, 11, 20)->startOfDay();
+        $statsReport->quarter->classroom1Date   = Carbon::create(2015, 12, 4)->startOfDay();
+        $statsReport->quarter->classroom2Date   = Carbon::create(2016, 1, 8)->startOfDay();
+        $statsReport->quarter->classroom3Date   = Carbon::create(2016, 2, 5)->startOfDay();
+        $statsReport->quarter->endWeekendDate   = Carbon::create(2016, 2, 19)->startOfDay();
+
+        $settings = [
+            [
+                'reportingDate' => 'week1',
+                'time'          => '8:00:59pm',
+            ],
+            [
+                'reportingDate' => 'classroom1Date',
+                'time'          => '7:00:59pm',
+            ],
+            [
+                'reportingDate' => 'classroom2Date',
+                'time'          => '11:59:59pm',
+            ],
+            [
+                'reportingDate' => 'classroom3Date',
+                'time'          => '7:00:59pm',
+            ],
+            [
+                'reportingDate' => 'endWeekendDate',
+                'time'          => '5:00:59pm',
+                'timezone'      => 'America/Chicago',
+            ],
+            [
+                'reportingDate' => '2016-01-01',
+                'dueDate'       => '2015-12-31',
+                'time'          => '5:00:59pm',
+            ],
+        ];
+
+        return [
+            // Report standard week with no override
+            [
+                $statsReport,
+                Carbon::create(2015, 11, 27)->startOfDay(),
+                [],
+                Carbon::create(2015, 11, 27, 19, 0, 59, $timezone),
+            ],
+            // Report week1 override
+            [
+                $statsReport,
+                Carbon::create(2015, 11, 27)->startOfDay(),
+                $settings,
+                Carbon::create(2015, 11, 27, 20, 0, 59, $timezone),
+            ],
+            // Report classroom1 override
+            [
+                $statsReport,
+                $statsReport->quarter->classroom1Date,
+                $settings,
+                Carbon::parse($statsReport->quarter->classroom1Date->toDateString() . " 7:00:59pm", $timezone),
+            ],
+            // Report classroom2 override
+            [
+                $statsReport,
+                $statsReport->quarter->classroom2Date,
+                $settings,
+                Carbon::parse($statsReport->quarter->classroom2Date->toDateString() . " 11:59:59pm", $timezone),
+            ],
+            // Report classroom3 override
+            [
+                $statsReport,
+                $statsReport->quarter->classroom3Date,
+                $settings,
+                Carbon::parse($statsReport->quarter->classroom3Date->toDateString() . " 7:00:59pm", $timezone),
+            ],
+            // Report weekend completion override
+            [
+                $statsReport,
+                $statsReport->quarter->endWeekendDate,
+                $settings,
+                Carbon::parse($statsReport->quarter->endWeekendDate->toDateString() . " 5:00:59pm", 'America/Chicago'),
+            ],
+            // Report specific reportingDate override
+            [
+                $statsReport,
+                Carbon::create(2016, 1, 1)->startOfDay(),
+                $settings,
+                Carbon::create(2015, 12, 31, 17, 0, 59, $timezone),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerGetRegionalRespondByDateTime
+     */
+    public function testGetRegionalRespondByDateTime($statsReport, $reportingDate, $settingData, $expectedResponse)
+    {
+        $this->unsetSetting('centerReportRespondByTime');
+        if ($settingData !== null) {
+            $this->setSetting('centerReportRespondByTime', json_encode($settingData));
+        }
+
+        $statsReport->reportingDate = $reportingDate;
+
+        $result = ImportManager::getRegionalRespondByDateTime($statsReport);
+
+        $this->assertInstanceOf(Carbon::class, $result);
+        $this->assertTrue($expectedResponse->eq($result));
+    }
+
+    public function providerGetRegionalRespondByDateTime()
+    {
+        $timezone = 'America/Vancouver';
+
+        $statsReport                   = new stdClass;
+        $statsReport->center           = new Center();
+        $statsReport->center->id       = 0;
+        $statsReport->center->timezone = $timezone;
+
+        $statsReport->quarter                   = new stdClass;
+        $statsReport->quarter->startWeekendDate = Carbon::create(2015, 11, 20)->startOfDay();
+        $statsReport->quarter->classroom1Date   = Carbon::create(2015, 12, 4)->startOfDay();
+        $statsReport->quarter->classroom2Date   = Carbon::create(2016, 1, 8)->startOfDay();
+        $statsReport->quarter->classroom3Date   = Carbon::create(2016, 2, 5)->startOfDay();
+        $statsReport->quarter->endWeekendDate   = Carbon::create(2016, 2, 19)->startOfDay();
+
+        $settings = [
+            [
+                'reportingDate' => 'week1',
+                'dueDate'       => '+1day',
+                'time'          => '12:00:00pm',
+            ],
+            [
+                'reportingDate' => 'classroom1Date',
+                'dueDate'       => '+1day',
+                'time'          => '10:00:00am',
+            ],
+            [
+                'reportingDate' => 'classroom2Date',
+                'dueDate'       => '+1day',
+                'time'          => '12:00:00pm',
+            ],
+            [
+                'reportingDate' => 'classroom3Date',
+                'time'          => '9:00:00pm',
+            ],
+            [
+                'reportingDate' => '2016-01-01',
+                'dueDate'       => '2015-12-31',
+                'time'          => '9:00:00pm',
+            ],
+        ];
+
+        return [
+            // Report standard week with no override
+            [
+                $statsReport,
+                Carbon::create(2015, 11, 27)->startOfDay(),
+                [],
+                Carbon::create(2015, 11, 28, 10, 0, 59, $timezone),
+            ],
+            // Report classroom1 override next day
+            [
+                $statsReport,
+                $statsReport->quarter->classroom1Date,
+                $settings,
+                Carbon::parse($statsReport->quarter->classroom1Date->copy()->addDay()->toDateString() . " 10:00:00am", $timezone),
+            ],
+            // Report classroom2 override next day
+            [
+                $statsReport,
+                $statsReport->quarter->classroom2Date,
+                $settings,
+                Carbon::parse($statsReport->quarter->classroom2Date->copy()->addDay()->toDateString() . " 12:00:00pm", $timezone),
+            ],
+            // Report classroom3 override same day
+            [
+                $statsReport,
+                $statsReport->quarter->classroom3Date,
+                $settings,
+                Carbon::parse($statsReport->quarter->classroom3Date->toDateString() . " 9:00:00pm", $timezone),
+            ],
+            // Report specific reportingDate specific response date
+            [
+                $statsReport,
+                Carbon::create(2016, 1, 1)->startOfDay(),
+                $settings,
+                Carbon::create(2015, 12, 31, 21, 0, 00, $timezone),
+            ],
+        ];
+    }
+}

--- a/src/tests/unit/Traits/MocksSettings.php
+++ b/src/tests/unit/Traits/MocksSettings.php
@@ -27,7 +27,7 @@ trait MocksSettings
      * @param     $name
      * @param int $centerId
      */
-    public function unsetSetting($name, $centerId = 0)
+    public function unsetSetting($name, $centerId = null)
     {
         ModelCache::create()->forget($name, $centerId);
     }


### PR DESCRIPTION
These new settings are pulled in from the Settings table and parsed to
provide the values by region or center. It also supports specifying multiple
reporting dates at once so you can input all of the info for the quarter.

Also added unit tests and improved code doc