### PR TITLE
Add managed users and unsubscribed people

### DIFF
--- a/src/app/Import/ImportManager.php
+++ b/src/app/Import/ImportManager.php
@@ -3,6 +3,7 @@ namespace TmlpStats\Import;
 
 use TmlpStats\Import\Xlsx\XlsxArchiver;
 use TmlpStats\GlobalReport;
+use TmlpStats\Person;
 use TmlpStats\ReportToken;
 use TmlpStats\Setting;
 
@@ -19,7 +20,13 @@ ini_set('max_execution_time', 240);
 ini_set('memory_limit', '512M');
 ini_set('max_file_uploads', '30');
 
-// ImportManager takes the list of uploaded files, has them all processed, and returns an array of results
+
+/**
+ * Class ImportManager
+ * @package TmlpStats\Import
+ *
+ * ImportManager takes the list of uploaded files, has them all processed, and returns an array of results
+ */
 class ImportManager
 {
     protected $files = array();
@@ -29,6 +36,13 @@ class ImportManager
 
     protected $results = array();
 
+    /**
+     * ImportManager constructor.
+     *
+     * @param             $files
+     * @param null|string $expectedDate
+     * @param bool|true   $enforceVersion
+     */
     public function __construct($files, $expectedDate = null, $enforceVersion = true)
     {
         $this->files = $files;
@@ -38,16 +52,32 @@ class ImportManager
         $this->enforceVersion = $enforceVersion;
     }
 
+    /**
+     * Specify whether or not to skip sending emails after processing a stats report
+     *
+     * @param bool|true $skip
+     */
     public function setSkipEmail($skip = true)
     {
         $this->skipEmail = $skip;
     }
 
+    /**
+     * Get the import/validation results
+     *
+     * @return array
+     */
     public function getResults()
     {
         return $this->results;
     }
 
+    /**
+     * Perform import. If $saveReport is provided and true, the files provided in the constructor will be imported
+     * and saved.
+     *
+     * @param bool|false $saveReport
+     */
     public function import($saveReport = false)
     {
         $successSheets = array();
@@ -164,6 +194,11 @@ class ImportManager
         $this->results['unknownFiles'] = $unknownFiles;
     }
 
+    /**
+     * Get the expected reported date based on day of week.
+     *
+     * @return Carbon datetime object
+     */
     public static function getExpectedReportDate()
     {
         $expectedDate = null;
@@ -186,6 +221,15 @@ class ImportManager
         return $expectedDate->startOfDay();
     }
 
+    /**
+     * Send emails for the provided report to the configured accountables
+     *
+     * @param $statsReport
+     * @param $sheet
+     *
+     * @return array
+     * @throws Exception
+     */
     public static function sendStatsSubmittedEmail($statsReport, $sheet)
     {
         if (!$statsReport || !$statsReport->submittedAt) {
@@ -214,13 +258,13 @@ class ImportManager
 
         $emailMap = array(
             'center'                 => $center->statsEmail,
-            'programManager'         => $programManager ? $programManager->email : null,
-            'classroomLeader'        => $classroomLeader ? $classroomLeader->email : null,
-            't1TeamLeader'           => $t1TeamLeader ? $t1TeamLeader->email : null,
-            't2TeamLeader'           => $t2TeamLeader ? $t2TeamLeader->email : null,
-            'statistician'           => $statistician ? $statistician->email : null,
-            'statisticianApprentice' => $statisticianApprentice ? $statisticianApprentice->email : null,
             'regional'               => $center->region->email,
+            'programManager'         => static::getEmail($programManager),
+            'classroomLeader'        => static::getEmail($classroomLeader),
+            't1TeamLeader'           => static::getEmail($t1TeamLeader),
+            't2TeamLeader'           => static::getEmail($t2TeamLeader),
+            'statistician'           => static::getEmail($statistician),
+            'statisticianApprentice' => static::getEmail($statisticianApprentice),
         );
 
         $mailingList = Setting::get('centerReportMailingList', $center);
@@ -303,6 +347,20 @@ class ImportManager
         }
 
         return $result;
+    }
+
+    /**
+     * Return person's email if they are not marked unsubscribed
+     *
+     * @param Person $person
+     *
+     * @return array|mixed|null
+     */
+    public static function getEmail(Person $person)
+    {
+        return $person && !$person->unsubscribed
+            ? $person->email
+            : null;
     }
 
     /**

--- a/src/app/Import/ImportManager.php
+++ b/src/app/Import/ImportManager.php
@@ -356,9 +356,9 @@ class ImportManager
      *
      * @return array|mixed|null
      */
-    public static function getEmail(Person $person)
+    public static function getEmail(Person $person = null)
     {
-        return $person && !$person->unsubscribed
+        return ($person && !$person->unsubscribed)
             ? $person->email
             : null;
     }

--- a/src/app/Person.php
+++ b/src/app/Person.php
@@ -44,7 +44,7 @@ class Person extends Model
      * @param            $first
      * @param            $last
      * @param            $center
-     * @param bool|false $recursed
+     * @param bool|false $replaced
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */

--- a/src/app/Person.php
+++ b/src/app/Person.php
@@ -19,6 +19,11 @@ class Person extends Model
         'email',
         'center_id',
         'identifier',
+        'unsubscribed',
+    ];
+
+    protected $casts = [
+        'unsubscribed' => 'boolean',
     ];
 
     public function __get($name)
@@ -46,17 +51,17 @@ class Person extends Model
     protected static function findByName($first, $last, $center, $replaced = false)
     {
         $possibleMembers = Person::firstName($first)
-            ->lastName($last)
-            ->byCenter($center)
-            ->get();
+                                 ->lastName($last)
+                                 ->byCenter($center)
+                                 ->get();
 
         // If we didn't find anyone. Maybe they gave their first name here.
         // Try with just the first letter
         if ($possibleMembers->isEmpty() && strlen($last) > 1) {
             $possibleMembers = Person::firstName($first)
-                ->lastName($last[0]) // Just the first letter
-                ->byCenter($center)
-                ->get();
+                                     ->lastName($last[0])// Just the first letter
+                                     ->byCenter($center)
+                                     ->get();
         }
 
         // If we still haven't found one, try some common character replacements
@@ -85,6 +90,11 @@ class Person extends Model
         return $possibleMembers;
     }
 
+    /**
+     * Get a list of the accountabilities person currently holds
+     *
+     * @return array
+     */
     public function getAccountabilities()
     {
         $allAccountabilities = $this->accountabilities()->get();
@@ -107,6 +117,13 @@ class Person extends Model
         return $accountabilities;
     }
 
+    /**
+     * Does person hold provided accountability
+     *
+     * @param Accountability $accountability
+     *
+     * @return bool
+     */
     public function hasAccountability(Accountability $accountability)
     {
         $accountabilities = $this->getAccountabilities();
@@ -115,9 +132,17 @@ class Person extends Model
                 return true;
             }
         }
+
         return false;
     }
 
+    /**
+     * Add accountability for person
+     *
+     * @param Accountability $accountability
+     * @param Carbon|null    $starts
+     * @param Carbon|null    $ends
+     */
     public function addAccountability(Accountability $accountability, Carbon $starts = null, Carbon $ends = null)
     {
         if (!$this->hasAccountability($accountability)) {
@@ -126,27 +151,45 @@ class Person extends Model
         }
     }
 
+    /**
+     * Remove accountability from person
+     *
+     * @param Accountability $accountability
+     */
     public function removeAccountability(Accountability $accountability)
     {
         if ($this->hasAccountability($accountability)) {
             DB::table('accountability_person')
-                ->where('person_id', $this->id)
-                ->where('accountability_id', $accountability->id)
-                ->update(['ends_at' => Util::now()->copy()->subSecond()]);
+              ->where('person_id', $this->id)
+              ->where('accountability_id', $accountability->id)
+              ->update(['ends_at' => Util::now()->copy()->subSecond()]);
         }
     }
 
+    /**
+     * Get the Region where the person's center is located
+     *
+     * @return null|Center
+     */
     public function homeRegion()
     {
         return $this->center ? $this->center->region : null;
     }
 
+    /**
+     * Get the user's formatted phone number
+     * e.g.
+     *      (555) 555-5555
+     *
+     * @return string|void
+     */
     public function formatPhone()
     {
         // TODO: This handles the standard 10 digit North American phone number. Update to handle international formats
         if (isset($this->phone) && preg_match('/^(\d\d\d)[\s\.\-]?(\d\d\d)[\s\.\-]?(\d\d\d\d)$/', $this->phone, $matches)) {
             return "({$matches[1]}) {$matches[2]}-{$matches[3]}";
         }
+
         return $this->phone;
     }
 
@@ -169,11 +212,11 @@ class Person extends Model
     {
         return $query->whereHas('accountabilities', function ($query) use ($accountability) {
             $query->whereName($accountability->name)
-                ->where('starts_at', '<=', Util::now())
-                ->where(function ($query) {
-                    $query->where('ends_at', '>', Util::now())
-                        ->orWhereNull('ends_at');
-                });
+                  ->where('starts_at', '<=', Util::now())
+                  ->where(function ($query) {
+                      $query->where('ends_at', '>', Util::now())
+                            ->orWhereNull('ends_at');
+                  });
         });
     }
 
@@ -185,8 +228,8 @@ class Person extends Model
     public function accountabilities()
     {
         return $this->belongsToMany('TmlpStats\Accountability', 'accountability_person', 'person_id', 'accountability_id')
-            ->withPivot(['starts_at', 'ends_at'])
-            ->withTimestamps();
+                    ->withPivot(['starts_at', 'ends_at'])
+                    ->withTimestamps();
     }
 
     public function center()

--- a/src/app/User.php
+++ b/src/app/User.php
@@ -33,11 +33,13 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         'active',
         'require_password_reset',
         'last_login_at',
+        'managed',
     ];
 
     protected $casts = [
         'active'                 => 'boolean',
         'require_password_reset' => 'boolean',
+        'managed'                => 'boolean',
     ];
 
     protected $dates = [
@@ -53,6 +55,15 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
     protected $reportToken = null;
 
+    /**
+     * Getter
+     *
+     * Used mostly to abstract relationships
+     *
+     * @param string $name
+     *
+     * @return mixed|null|string
+     */
     public function __get($name)
     {
         if ($this->reportToken) {
@@ -74,6 +85,13 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         }
     }
 
+    /**
+     * Getter to be used for report-only users
+     *
+     * @param $name
+     *
+     * @return mixed|null|string
+     */
     protected function getForReportUser($name)
     {
         switch ($name) {
@@ -98,11 +116,23 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         $this->reportToken = $reportToken;
     }
 
+    /**
+     * Is Admin convenience function
+     *
+     * @return bool
+     */
     public function isAdmin()
     {
         return $this->hasRole('administrator');
     }
 
+    /**
+     * Does user have provided accountability
+     *
+     * @param $name Accountability name
+     *
+     * @return bool
+     */
     public function hasAccountability($name)
     {
         return $this->person
@@ -110,11 +140,23 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             : false;
     }
 
+    /**
+     * Does user have provided role
+     *
+     * @param $name Role name
+     *
+     * @return bool
+     */
     public function hasRole($name)
     {
         return ($this->role && $this->role->name === $name);
     }
 
+    /**
+     * Get the Region of the user's home center
+     *
+     * @return null|Region
+     */
     public function homeRegion()
     {
         if ($this->reportToken) {
@@ -128,61 +170,93 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
             : null;
     }
 
+    /**
+     * Set the user's center
+     *
+     * @param Center $center
+     */
     public function setCenter($center)
     {
         if (!$this->person) {
             return;
         }
 
-        $person = $this->person;
+        $person           = $this->person;
         $person->centerId = $center->id;
         $person->save();
     }
 
+    /**
+     * Set the user's First Name
+     *
+     * @param $firstName
+     */
     public function setFirstName($firstName)
     {
         if (!$this->person) {
             return;
         }
 
-        $person = $this->person;
+        $person            = $this->person;
         $person->firstName = $firstName;
         $person->save();
     }
 
+    /**
+     * Set the user's Last Name
+     *
+     * @param $lastName
+     */
     public function setLastName($lastName)
     {
         if (!$this->person) {
             return;
         }
 
-        $person = $this->person;
+        $person           = $this->person;
         $person->lastName = $lastName;
         $person->save();
     }
 
+    /**
+     * Set the user's phone number
+     *
+     * @param $phone
+     */
     public function setPhone($phone)
     {
         if (!$this->person) {
             return;
         }
 
-        $person = $this->person;
+        $person        = $this->person;
         $person->phone = $phone;
         $person->save();
     }
 
+    /**
+     * Set the user's email address
+     *
+     * @param $email
+     */
     public function setEmail($email)
     {
         if (!$this->person) {
             return;
         }
 
-        $person = $this->person;
+        $person        = $this->person;
         $person->email = $email;
         $person->save();
     }
 
+    /**
+     * Get the user's formatted phone number
+     * e.g.
+     *      (555) 555-5555
+     *
+     * @return string|void
+     */
     public function formatPhone()
     {
         if (!$this->person) {
@@ -193,6 +267,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
         if (isset($this->person->phone) && preg_match('/^(\d\d\d)[\s\.\-]?(\d\d\d)[\s\.\-]?(\d\d\d\d)$/', $this->person->phone, $matches)) {
             return "({$matches[1]}) {$matches[2]}-{$matches[3]}";
         }
+
         return $this->person->phone;
     }
 

--- a/src/database/migrations/2015_12_22_053158_add_managed_to_users_table.php
+++ b/src/database/migrations/2015_12_22_053158_add_managed_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddManagedToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('managed')->default(false)->after('active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('managed');
+        });
+    }
+}

--- a/src/database/migrations/2015_12_22_053220_add_unsubscribed_to_people_table.php
+++ b/src/database/migrations/2015_12_22_053220_add_unsubscribed_to_people_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUnsubscribedToPeopleTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->boolean('unsubscribed')->default(false)->after('identifier');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropColumn('unsubscribed');
+        });
+    }
+}

--- a/src/tests/unit/Import/ImportManagerTest.php
+++ b/src/tests/unit/Import/ImportManagerTest.php
@@ -5,6 +5,7 @@ use Carbon\Carbon;
 use stdClass;
 use TmlpStats\Center;
 use TmlpStats\Import\ImportManager;
+use TmlpStats\Person;
 use TmlpStats\Tests\Traits\MocksSettings;
 
 class ImportManagerTest extends TestAbstract
@@ -12,6 +13,38 @@ class ImportManagerTest extends TestAbstract
     use MocksSettings;
 
     protected $testClass = ImportManager::class;
+
+    /**
+     * @dataProvider providerGetEmail
+     */
+    public function testGetEmail($person, $expectedResult)
+    {
+        $result = ImportManager::getEmail($person);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providerGetEmail()
+    {
+        $data = [];
+
+        // No person provided, should return null
+        $data[] = [null, null];
+
+        // Person is unsubscribed, should return null
+        $person = new Person([
+            'email'        => 'test@tmlpstats.com',
+            'unsubscribed' => true,
+        ]);
+        $data[] = [$person, null];
+
+        // Person is not unsubscribed, should return email
+        $person               = clone $person;
+        $person->unsubscribed = false;
+        $data[]               = [$person, 'test@tmlpstats.com'];
+
+        return $data;
+    }
 
     /**
      * @dataProvider providerGetStatsDueDateTime
@@ -203,14 +236,18 @@ class ImportManagerTest extends TestAbstract
                 $statsReport,
                 $statsReport->quarter->classroom1Date,
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom1Date->copy()->addDay()->toDateString() . " 10:00:00am", $timezone),
+                Carbon::parse($statsReport->quarter->classroom1Date->copy()
+                                                                   ->addDay()
+                                                                   ->toDateString() . " 10:00:00am", $timezone),
             ],
             // Report classroom2 override next day
             [
                 $statsReport,
                 $statsReport->quarter->classroom2Date,
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom2Date->copy()->addDay()->toDateString() . " 12:00:00pm", $timezone),
+                Carbon::parse($statsReport->quarter->classroom2Date->copy()
+                                                                   ->addDay()
+                                                                   ->toDateString() . " 12:00:00pm", $timezone),
             ],
             // Report classroom3 override same day
             [


### PR DESCRIPTION
- Add a field to the users table to mark a user as managed. This will be used to add tooling for regionals to manage these accounts collectively
- Add a field to the people table to mark a person unsubscribed. Unsubscribed people will not receive stats submitted emails even if they are accountable.
- Add more code doc

closes #248 
refers to #173 