### PR TITLE
Make quarter date settings configurable by center

### DIFF
--- a/src/app/Http/Controllers/CenterStatsController.php
+++ b/src/app/Http/Controllers/CenterStatsController.php
@@ -184,9 +184,8 @@ class CenterStatsController extends Controller
             );
         } else {
             // Get all weeks for stats report
-            $week = clone $statsReport->quarter->startWeekendDate;
-            $week->addWeek();
-            while ($week->lte($statsReport->quarter->endWeekendDate)) {
+            $week = $statsReport->quarter->getFirstWeekDate($statsReport->center);
+            while ($week->lte($statsReport->quarter->getQuarterEndDate($statsReport->center))) {
 
                 $weekData        = $this->getWeekData(
                     $week,
@@ -249,11 +248,11 @@ class CenterStatsController extends Controller
         $statsReport  = null;
 
         // Usually, promises will be saved in the global report for the expected week
-        if ($this->statsReport->reportingDate->gte($quarter->classroom2Date) && $date->gt($quarter->classroom2Date) && !$originalPromise) {
-            $globalReport = $this->getGlobalReport($quarter->classroom2Date);
+        $classroom2Date = $quarter->getClassroom2Date($center);
+        if ($this->statsReport->reportingDate->gte($classroom2Date) && $date->gt($classroom2Date) && !$originalPromise) {
+            $globalReport = $this->getGlobalReport($classroom2Date);
         } else {
-            $firstWeek = clone $quarter->startWeekendDate;
-            $firstWeek->addWeek();
+            $firstWeek = $quarter->getFirstWeekDate($center);
 
             $globalReport = $this->getGlobalReport($firstWeek);
         }
@@ -345,7 +344,7 @@ class CenterStatsController extends Controller
                                ->join('global_report_stats_report', 'global_report_stats_report.stats_report_id', '=', 'stats_reports.id')
                                ->join('global_reports', 'global_reports.id', '=', 'global_report_stats_report.global_report_id')
                                ->where('stats_reports.center_id', '=', $center->id)
-                               ->where('global_reports.reporting_date', '>', $quarter->startWeekendDate)
+                               ->where('global_reports.reporting_date', '>', $quarter->getQuarterStartDate($center))
                                ->where('center_stats_data.type', '=', $type)
                                ->orderBy('global_reports.reporting_date', 'ASC')
                                ->first();

--- a/src/app/Http/Controllers/GlobalReportController.php
+++ b/src/app/Http/Controllers/GlobalReportController.php
@@ -343,7 +343,7 @@ class GlobalReportController extends ReportDispatchAbstractController
         $quarter = Quarter::getQuarterByDate($globalReport->reportingDate, $region);
 
         $globalReportData = App::make(CenterStatsController::class)
-                               ->getByGlobalReportUnprocessed($globalReport, $region, $quarter->endWeekendDate, true);
+                               ->getByGlobalReportUnprocessed($globalReport, $region, $quarter->getQuarterEndDate(), true);
         if (!$globalReportData) {
             return null;
         }
@@ -363,7 +363,7 @@ class GlobalReportController extends ReportDispatchAbstractController
         foreach ($centersData as $centerName => $centerData) {
             $a                       = new Arrangements\GamesByWeek($centerData);
             $dataReport              = $a->compose();
-            $reportData[$centerName] = $dataReport['reportData'][$quarter->endWeekendDate->toDateString()];
+            $reportData[$centerName] = $dataReport['reportData'][$quarter->getQuarterEndDate()->toDateString()];
         }
 
         $totals = [];
@@ -395,7 +395,7 @@ class GlobalReportController extends ReportDispatchAbstractController
             $totals['gitw']['actual'] = round($totals['gitw']['actual'] / count($reportData));
         }
 
-        $includeActual   = $globalReport->reportingDate->eq($quarter->endWeekendDate);
+        $includeActual   = $globalReport->reportingDate->eq($quarter->getQuarterEndDate());
         $includeOriginal = true;
 
         return view('globalreports.details.centergames', compact(
@@ -736,7 +736,8 @@ class GlobalReportController extends ReportDispatchAbstractController
         $registeredAtWeekend = [];
         if ($registrations) {
             foreach ($registrations as $registration) {
-                $weekendStartDate = $registration->statsReport->quarter->startWeekendDate;
+                $statsReport = $registration->statsReport;
+                $weekendStartDate = $statsReport->quarter->getQuarterStartDate($statsReport->center);
                 if ($registration->teamYear == 2
                     && $registration->regDate->gt($weekendStartDate)
                     && $registration->regDate->lte($weekendStartDate->copy()->addDays(2))

--- a/src/app/Import/ImportManager.php
+++ b/src/app/Import/ImportManager.php
@@ -381,7 +381,7 @@ class ImportManager
                 $statsReport->reportingDate->year,
                 $statsReport->reportingDate->month,
                 $statsReport->reportingDate->day + 1,
-                10, 0, 59,
+                10, 0, 0,
                 $statsReport->center->timezone
             );
         }

--- a/src/app/Import/Xlsx/DataImporter/CenterStatsImporter.php
+++ b/src/app/Import/Xlsx/DataImporter/CenterStatsImporter.php
@@ -123,7 +123,7 @@ class CenterStatsImporter extends DataImporterAbstract
 
     public function postProcess()
     {
-        $isRepromiseWeek = $this->statsReport->reportingDate->eq($this->statsReport->quarter->classroom2Date);
+        $isRepromiseWeek = $this->statsReport->reportingDate->eq($this->statsReport->quarter->getClassroom2Date($this->statsReport->center));
 
         foreach ($this->data as $week) {
 
@@ -205,15 +205,15 @@ class CenterStatsImporter extends DataImporterAbstract
         $globalReport = null;
         $statsReport = null;
 
-        $firstWeek = clone $quarter->startWeekendDate;
-        $firstWeek->addWeek();
+        $firstWeek = $quarter->getFirstWeekDate($center);
 
         // Don't reuse promises on the first week, as they may change between submits
         if ($this->statsReport->reportingDate->ne($firstWeek)) {
 
             // Usually, promises will be saved in the global report for the expected week
-            if ($this->statsReport->reportingDate->gt($quarter->classroom2Date) && $date->gt($quarter->classroom2Date)) {
-                $globalReport = GlobalReport::reportingDate($quarter->classroom2Date)->first();
+            $classroom2Date = $quarter->getClassroom2Date($center);
+            if ($this->statsReport->reportingDate->gt($classroom2Date) && $date->gt($classroom2Date)) {
+                $globalReport = GlobalReport::reportingDate($classroom2Date)->first();
             } else {
                 $globalReport = GlobalReport::reportingDate($firstWeek)->first();
             }
@@ -256,7 +256,7 @@ class CenterStatsImporter extends DataImporterAbstract
             ->join('global_report_stats_report', 'global_report_stats_report.stats_report_id', '=', 'stats_reports.id')
             ->join('global_reports', 'global_reports.id', '=', 'global_report_stats_report.global_report_id')
             ->where('stats_reports.center_id', '=', $center->id)
-            ->where('global_reports.reporting_date', '>', $quarter->startWeekendDate)
+            ->where('global_reports.reporting_date', '>', $quarter->getQuarterStartDate($center))
             ->where('center_stats_data.type', '=', $type)
             ->orderBy('global_reports.reporting_date', 'ASC')
             ->first();

--- a/src/app/Import/Xlsx/DataImporter/TmlpGameInfoImporter.php
+++ b/src/app/Import/Xlsx/DataImporter/TmlpGameInfoImporter.php
@@ -77,8 +77,7 @@ class TmlpGameInfoImporter extends DataImporterAbstract
 
     public function getGameData($type, Center $center, Quarter $quarter)
     {
-        $firstWeek = clone $quarter->startWeekendDate;
-        $firstWeek->addWeek();
+        $firstWeek = $quarter->getFirstWeekDate($center);
 
         $globalReport = null;
         $statsReport = null;
@@ -121,7 +120,7 @@ class TmlpGameInfoImporter extends DataImporterAbstract
             ->join('global_report_stats_report', 'global_report_stats_report.stats_report_id', '=', 'stats_reports.id')
             ->join('global_reports', 'global_reports.id', '=', 'global_report_stats_report.global_report_id')
             ->where('stats_reports.center_id', '=', $center->id)
-            ->where('global_reports.reporting_date', '>', $quarter->startWeekendDate)
+            ->where('global_reports.reporting_date', '>', $quarter->getQuarterStartDate($center))
             ->where('tmlp_games_data.type', '=', $type)
             ->orderBy('global_reports.reporting_date', 'ASC')
             ->first();

--- a/src/app/Quarter.php
+++ b/src/app/Quarter.php
@@ -106,7 +106,7 @@ class Quarter extends Model
             }
         }
 
-        return $date;
+        return $date->startOfDay();
     }
 
     public static function isFirstWeek(Region $region)

--- a/src/app/Quarter.php
+++ b/src/app/Quarter.php
@@ -35,7 +35,7 @@ class Quarter extends Model
                 if (!$this->regionQuarterDetails) {
                     throw new Exception("Cannot call __get({$name}) before setting region.");
                 }
-                return $this->regionQuarterDetails->$name;
+                return $this->getQuarterDate($name);
 
             case 'firstWeekDate':
                 $startDate = clone $this->startWeekendDate;
@@ -43,6 +43,67 @@ class Quarter extends Model
             default:
                 return parent::__get($name);
         }
+    }
+
+    public function getQuarterStartDate(Center $center = null)
+    {
+        return $this->getQuarterDate('startWeekendDate', $center);
+    }
+
+    public function getQuarterEndDate(Center $center = null)
+    {
+        return $this->getQuarterDate('endWeekendDate', $center);
+    }
+
+    public function getClassroom1Date(Center $center = null)
+    {
+        return $this->getQuarterDate('classroom1Date', $center);
+    }
+
+    public function getClassroom2Date(Center $center = null)
+    {
+        return $this->getQuarterDate('classroom2Date', $center);
+    }
+
+    public function getClassroom3Date(Center $center = null)
+    {
+        return $this->getQuarterDate('classroom3Date', $center);
+    }
+
+    public function getQuarterDate($field, Center $center = null)
+    {
+        $validFields = [
+            'startWeekendDate',
+            'endWeekendDate',
+            'classroom1Date',
+            'classroom2Date',
+            'classroom3Date',
+        ];
+
+        if (!in_array($field, $validFields)) {
+            throw new \Exception("{$field} is not a valid date field.");
+        }
+
+        if (!$this->regionQuarterDetails) {
+            throw new \Exception("regionQuarterDetails not set. Cannot determine {$field}.");
+        }
+
+        $date = $this->regionQuarterDetails->$field;
+
+        $settings = Setting::get('regionQuarterOverride', $center);
+        if ($settings) {
+            // Settings should be in the format:
+            // {"classroom2Date":"2016-01-15", "classroom3Date":"2016-02-07"}
+            $dateSettings = $settings->value
+                ? json_decode($settings->value, true)
+                : [];
+
+            if (isset($dateSettings[$field])) {
+                $date = Carbon::parse($dateSettings[$field]);
+            }
+        }
+
+        return $date;
     }
 
     public static function isFirstWeek(Region $region)

--- a/src/app/Quarter.php
+++ b/src/app/Quarter.php
@@ -36,13 +36,16 @@ class Quarter extends Model
                     throw new Exception("Cannot call __get({$name}) before setting region.");
                 }
                 return $this->getQuarterDate($name);
-
-            case 'firstWeekDate':
-                $startDate = clone $this->startWeekendDate;
-                return $startDate->addWeek();
             default:
                 return parent::__get($name);
         }
+    }
+
+    public function getFirstWeekDate(Center $center = null)
+    {
+        $quarterStart = $this->getQuarterStartDate($center);
+
+        return $quarterStart->addWeek();
     }
 
     public function getQuarterStartDate(Center $center = null)
@@ -112,8 +115,7 @@ class Quarter extends Model
         $quarter = Quarter::getQuarterByDate($reportingDate, $region);
 
         if ($quarter) {
-            $firstWeek = clone $quarter->startWeekendDate;
-            $firstWeek->addWeek();
+            $firstWeek = $quarter->getFirstWeekDate();
             return $firstWeek->eq($reportingDate);
         }
         return false;

--- a/src/app/Reports/Arrangements/GamesByMilestone.php
+++ b/src/app/Reports/Arrangements/GamesByMilestone.php
@@ -19,11 +19,11 @@ class GamesByMilestone extends BaseArrangement
         $reportData = [];
         foreach ($weeks as $dateString => $weekData) {
             $weekDate = Carbon::createFromFormat('Y-m-d', $dateString)->startOfDay();
-            if ($weekDate->lte($quarter->classroom1Date)) {
+            if ($weekDate->lte($quarter->getClassroom1Date())) {
                 $classroom = 0;
-            } else if ($weekDate->lte($quarter->classroom2Date)) {
+            } else if ($weekDate->lte($quarter->getClassroom2Date())) {
                 $classroom = 1;
-            } else if ($weekDate->lte($quarter->classroom3Date)) {
+            } else if ($weekDate->lte($quarter->getClassroom3Date())) {
                 $classroom = 2;
             } else {
                 $classroom = 3;

--- a/src/app/StatsReport.php
+++ b/src/app/StatsReport.php
@@ -206,7 +206,7 @@ class StatsReport extends Model
             return $query;
         }
 
-        $lastQuarter = Quarter::getQuarterByDate($currentQuarter->startWeekendDate, $region);
+        $lastQuarter = Quarter::getQuarterByDate($currentQuarter->getQuarterStartDate(), $region);
         if (!$lastQuarter) {
             return $query;
         }
@@ -298,7 +298,7 @@ class StatsReport extends Model
                 if (in_array($reportingDate, $quarterDates)) {
                     $reportingDate = $statsReport->quarter->$reportingDate;
                 } else if ($reportingDate == 'week1') {
-                    $reportingDate = $statsReport->quarter->startWeekendDate->copy()->addWeek();
+                    $reportingDate = $statsReport->quarter->getFirstWeekDate($statsReport->center);
                 } else {
                     $reportingDate = Carbon::parse($reportingDate);
                 }

--- a/src/app/StatsReport.php
+++ b/src/app/StatsReport.php
@@ -296,7 +296,7 @@ class StatsReport extends Model
 
                 // Dates can be specified as a classroomDate
                 if (in_array($reportingDate, $quarterDates)) {
-                    $reportingDate = $statsReport->quarter->$reportingDate;
+                    $reportingDate = $statsReport->quarter->getQuarterDate($reportingDate, $statsReport->center);
                 } else if ($reportingDate == 'week1') {
                     $reportingDate = $statsReport->quarter->getFirstWeekDate($statsReport->center);
                 } else {

--- a/src/app/TeamMember.php
+++ b/src/app/TeamMember.php
@@ -69,7 +69,7 @@ class TeamMember extends Model
 
         $incomingQuarter = Quarter::findForCenter($attributes['incoming_quarter_id'], $center);
 
-        $quarterStartDateString = $incomingQuarter->startWeekendDate->toDateString();
+        $quarterStartDateString = $incomingQuarter->getQuarterStartDate($center)->toDateString();
 
         // This identifier is designed to help us distinguish between 'people' from a center
         // with the same name. It's not perfect, but it should work well enough

--- a/src/app/Traits/ValidatesTravelWithConfig.php
+++ b/src/app/Traits/ValidatesTravelWithConfig.php
@@ -16,7 +16,7 @@ trait ValidatesTravelWithConfig
 
         $travelDueSetting = Setting::get('travelDueByDate', $this->statsReport->center);
 
-        $dueDate = $this->statsReport->quarter->classroom2Date;
+        $dueDate = $this->statsReport->quarter->getClassroom2Date($this->statsReport->center);
         if ($travelDueSetting) {
             $settingValue = $travelDueSetting->value;
             if (in_array($settingValue, $classroomNames)) {

--- a/src/app/Traits/ValidatesTravelWithConfig.php
+++ b/src/app/Traits/ValidatesTravelWithConfig.php
@@ -20,7 +20,7 @@ trait ValidatesTravelWithConfig
         if ($travelDueSetting) {
             $settingValue = $travelDueSetting->value;
             if (in_array($settingValue, $classroomNames)) {
-                $dueDate = $this->statsReport->quarter->$settingValue;
+                $dueDate = $this->statsReport->quarter->getQuarterDate($settingValue, $this->statsReport->center);
             } else if (preg_match('/^\d\d\d\d-\d\d-\d\d$/', $settingValue)) {
                 $dueDate = Carbon::parse($settingValue);
             }

--- a/src/app/Validate/Objects/CommCourseInfoValidator.php
+++ b/src/app/Validate/Objects/CommCourseInfoValidator.php
@@ -102,7 +102,7 @@ class CommCourseInfoValidator extends ObjectsValidatorAbstract
         $isValid = true;
 
         $startDate = $this->getDateObject($data->startDate);
-        if ($startDate && $startDate->lt($this->statsReport->quarter->startWeekendDate)) {
+        if ($startDate && $startDate->lt($this->statsReport->quarter->getQuarterStartDate($this->statsReport->center))) {
             $this->addMessage('COMMCOURSE_COURSE_DATE_BEFORE_QUARTER');
             $isValid = false;
         }

--- a/src/app/Validate/Objects/StatsReportValidator.php
+++ b/src/app/Validate/Objects/StatsReportValidator.php
@@ -25,10 +25,11 @@ class StatsReportValidator extends ValidatorAbstract
 
         if ($expectedDate && $expectedDate->ne($this->statsReport->reportingDate)) {
 
-            if ($this->statsReport->reportingDate->diffInDays($this->statsReport->quarter->endWeekendDate) < 7) {
+            $quarterEndDate = $this->statsReport->quarter->getQuarterEndDate($this->statsReport->center);
+            if ($this->statsReport->reportingDate->diffInDays($quarterEndDate) < 7) {
                 // Reporting in the last week of quarter
-                if ($this->statsReport->reportingDate->ne($this->statsReport->quarter->endWeekendDate)) {
-                    $this->addMessage('IMPORTDOC_SPREADSHEET_DATE_MISMATCH_LAST_WEEK', $this->statsReport->reportingDate->toDateString(), $this->statsReport->quarter->endWeekendDate->toDateString());
+                if ($this->statsReport->reportingDate->ne($quarterEndDate)) {
+                    $this->addMessage('IMPORTDOC_SPREADSHEET_DATE_MISMATCH_LAST_WEEK', $this->statsReport->reportingDate->toDateString(), $quarterEndDate->toDateString());
                     $this->isValid = false;
                 }
             } else {

--- a/src/app/Validate/Objects/TmlpRegistrationValidator.php
+++ b/src/app/Validate/Objects/TmlpRegistrationValidator.php
@@ -287,16 +287,17 @@ class TmlpRegistrationValidator extends ObjectsValidatorAbstract
 
         // Make sure Weekend Reg fields match registration date
         if ($data->incomingWeekend == 'current') {
-            $dateStr = $this->statsReport->quarter->startWeekendDate->format('M d, Y');
-            if (!is_null($data->bef) && $regDate && $regDate->gt($this->statsReport->quarter->startWeekendDate)) {
+            $quarterStartDate = $this->statsReport->quarter->getQuarterStartDate($this->statsReport->center);
+            $dateStr = $quarterStartDate->format('M d, Y');
+            if (!is_null($data->bef) && $regDate && $regDate->gt($quarterStartDate)) {
                 $this->addMessage('TMLPREG_BEF_REG_DATE_NOT_BEFORE_WEEKEND', $dateStr, $data->bef);
                 $isValid = false;
             }
-            if (!is_null($data->dur) && $regDate && $regDate->diffInDays($this->statsReport->quarter->startWeekendDate) > 3) {
+            if (!is_null($data->dur) && $regDate && $regDate->diffInDays($quarterStartDate) > 3) {
                 $this->addMessage('TMLPREG_DUR_REG_DATE_NOT_DURING_WEEKEND', $dateStr, $data->dur);
                 $isValid = false;
             }
-            if (!is_null($data->aft) && $regDate && $regDate->lte($this->statsReport->quarter->startWeekendDate)) {
+            if (!is_null($data->aft) && $regDate && $regDate->lte($quarterStartDate)) {
                 $this->addMessage('TMLPREG_AFT_REG_DATE_NOT_AFTER_WEEKEND', $dateStr, $data->aft);
                 $isValid = false;
             }

--- a/src/app/Validate/Relationships/TeamExpansionValidator.php
+++ b/src/app/Validate/Relationships/TeamExpansionValidator.php
@@ -13,8 +13,7 @@ class TeamExpansionValidator extends ValidatorAbstract
     {
         $calculatedCounts = $this->calculateQuarterStartingCounts($data['tmlpRegistration']);
 
-        $quarterStart  = clone $this->quarter->startWeekendDate;
-        $firstWeekDate = $quarterStart->addDays(7);
+        $firstWeekDate = $this->quarter->getFirstWeekDate($this->statsReport->center);
 
         $reportedCounts = [
             'team1' => [
@@ -122,14 +121,16 @@ class TeamExpansionValidator extends ValidatorAbstract
 
             $regDate = Util::parseUnknownDateFormat($registration['regDate']);
 
-            if ($regDate && $regDate->lte($this->quarter->startWeekendDate)) {
+            $quarterStartDate = $this->quarter->getQuarterStartDate($this->statsReport->center);
+
+            if ($regDate && $regDate->lte($quarterStartDate)) {
                 $output[$team][$weekend]['registered']++;
             }
 
             if ($registration['apprDate']) {
                 $apprDate = Util::parseUnknownDateFormat($registration['apprDate']);
 
-                if ($apprDate && $apprDate->lte($this->quarter->startWeekendDate)) {
+                if ($apprDate && $apprDate->lte($quarterStartDate)) {
                     $output[$team][$weekend]['approved']++;
                 }
             }

--- a/src/resources/views/globalreports/details/applicationsbycenter.blade.php
+++ b/src/resources/views/globalreports/details/applicationsbycenter.blade.php
@@ -25,7 +25,7 @@
                                 <td>{{ $registrationData->firstName }} {{ $registrationData->lastName }}</td>
                                 <td>
                                     @if ($registrationData->regDate)
-                                        @if ($registrationData->regDate->gt($registrationData->statsReport->quarter->startWeekendDate))
+                                        @if ($registrationData->regDate->gt($registrationData->statsReport->quarter->getQuarterStartDate($registrationData->center)))
                                             Current
                                         @else
                                             Prior

--- a/src/resources/views/globalreports/details/applicationsbystatus.blade.php
+++ b/src/resources/views/globalreports/details/applicationsbystatus.blade.php
@@ -56,7 +56,7 @@
                             </td>
                             <td>{{ $registrationData->firstName }} {{ $registrationData->lastName }}</td>
                             <td class="data-point">{{ $registrationData->registration->teamYear }}</td>
-                            <td>{{ $registrationData->incomingQuarter ? $registrationData->incomingQuarter->startWeekendDate->format('M Y') : '' }}</td>
+                            <td>{{ $registrationData->incomingQuarter ? $registrationData->incomingQuarter->getQuarterStartDate($registrationData->center)->format('M Y') : '' }}</td>
                             <td class="data-point">
                                 @if ($registrationData->regDate)
                                     @date($registrationData->regDate)

--- a/src/resources/views/globalreports/show.blade.php
+++ b/src/resources/views/globalreports/show.blade.php
@@ -57,14 +57,14 @@
                     <div class="btn-group" role="group">
                         <button id ="regionalstats-button" type="button" class="btn">Scoreboard</button>
                         <button id ="gamesbycenter-button" type="button" class="btn">By Center</button>
-                        @if ($globalReport->reportingDate->gte($quarter->classroom2Date))
+                        @if ($globalReport->reportingDate->gte($quarter->getClassroom2Date()))
                         <button id ="repromisesbycenter-button" type="button" class="btn">Repromises</button>
                         @endif
                     </div>
 
                     <div id="regionalstats-container"></div>
                     <div id="gamesbycenter-container"></div>
-                    @if ($globalReport->reportingDate->gte($quarter->classroom2Date))
+                    @if ($globalReport->reportingDate->gte($quarter->getClassroom2Date()))
                     <div id="repromisesbycenter-container"></div>
                     @endif
                 </div>
@@ -158,7 +158,7 @@
             'tdosummary',
             'regionalstats',
             'gamesbycenter',
-            @if ($globalReport->reportingDate->gte($quarter->classroom2Date))
+            @if ($globalReport->reportingDate->gte($quarter->getClassroom2Date()))
             'repromisesbycenter',
             @endif
         ];
@@ -210,7 +210,7 @@
             [
                 'regionalstats',
                 'gamesbycenter',
-                @if ($globalReport->reportingDate->gte($quarter->classroom2Date))
+                @if ($globalReport->reportingDate->gte($quarter->getClassroom2Date()))
                 'repromisesbycenter',
                 @endif
             ],

--- a/src/resources/views/statsreports/details/peopletransfersummary.blade.php
+++ b/src/resources/views/statsreports/details/peopletransfersummary.blade.php
@@ -148,9 +148,9 @@
                                 } else {
                                     if ($old) {
                                         echo 'Withdrawn last quarter: ' . $old->withdrawCode->display;
-                                    } else if ($new->regDate->lt($thisQuarter->startWeekendDate)) {
+                                    } else if ($new->regDate->lt($thisQuarter->getQuarterStartDate($incoming->center))) {
                                         echo 'Registered before quarter (' . $new->regDate->format('M j, Y') . '), but was not on last quarter\'s final sheet';
-                                    } else if ($new->teamYear == 2 && $new->regDate->diffInDays($thisQuarter->startWeekendDate) < 4) {
+                                    } else if ($new->teamYear == 2 && $new->regDate->diffInDays($thisQuarter->getQuarterStartDate($incoming->center)) < 4) {
                                         echo 'Registered at the weekend.';
                                     }
                                 }

--- a/src/resources/views/statsreports/show.blade.php
+++ b/src/resources/views/statsreports/show.blade.php
@@ -52,7 +52,7 @@
             @can ('readContactInfo', $statsReport)
             <li><a href="#contactinfo" data-toggle="tab">Contact Info</a></li>
             @endcan
-            @if ($statsReport->reportingDate->eq($statsReport->quarter->firstWeekDate))
+            @if ($statsReport->reportingDate->eq($statsReport->quarter->getFirstWeekDate($statsReport->center)))
             <li><a href="#transitionsummary" data-toggle="tab">Transfer Check</a></li>
             @endif
             <li><a href="#weekend" data-toggle="tab">Weekend</a></li>
@@ -103,7 +103,7 @@
                 <div id="contactinfo-container"></div>
             </div>
             @endcan
-            @if ($statsReport->reportingDate->eq($statsReport->quarter->firstWeekDate))
+            @if ($statsReport->reportingDate->eq($statsReport->quarter->getFirstWeekDate($statsReport->center)))
             <div class="tab-pane" id="transitionsummary">
                 <h3>Transfer Check</h3>
                 <div class="btn-group" role="group">
@@ -144,7 +144,7 @@
             @can ('readContactInfo', $statsReport)
             'contactinfo',
             @endcan
-            @if ($statsReport->reportingDate->eq($statsReport->quarter->firstWeekDate))
+            @if ($statsReport->reportingDate->eq($statsReport->quarter->getFirstWeekDate($statsReport->center)))
             'peopletransfersummary',
             'coursestransfersummary',
             @endif

--- a/src/tests/unit/Import/ImportManagerTest.php
+++ b/src/tests/unit/Import/ImportManagerTest.php
@@ -6,11 +6,12 @@ use stdClass;
 use TmlpStats\Center;
 use TmlpStats\Import\ImportManager;
 use TmlpStats\Person;
+use TmlpStats\Tests\Traits\MocksQuarters;
 use TmlpStats\Tests\Traits\MocksSettings;
 
 class ImportManagerTest extends TestAbstract
 {
-    use MocksSettings;
+    use MocksSettings, MocksQuarters;
 
     protected $testClass = ImportManager::class;
 
@@ -75,12 +76,13 @@ class ImportManagerTest extends TestAbstract
         $statsReport->center->id       = 0;
         $statsReport->center->timezone = $timezone;
 
-        $statsReport->quarter                   = new stdClass;
-        $statsReport->quarter->startWeekendDate = Carbon::create(2015, 11, 20)->startOfDay();
-        $statsReport->quarter->classroom1Date   = Carbon::create(2015, 12, 4)->startOfDay();
-        $statsReport->quarter->classroom2Date   = Carbon::create(2016, 1, 8)->startOfDay();
-        $statsReport->quarter->classroom3Date   = Carbon::create(2016, 2, 5)->startOfDay();
-        $statsReport->quarter->endWeekendDate   = Carbon::create(2016, 2, 19)->startOfDay();
+        $statsReport->quarter          = $this->getQuarterMock([], [
+            'startWeekendDate' => Carbon::create(2015, 11, 20)->startOfDay(),
+            'classroom1Date'   => Carbon::create(2015, 12, 4)->startOfDay(),
+            'classroom2Date'   => Carbon::create(2016, 1, 8)->startOfDay(),
+            'classroom3Date'   => Carbon::create(2016, 2, 5)->startOfDay(),
+            'endWeekendDate'   => Carbon::create(2016, 2, 19)->startOfDay(),
+        ]);
 
         $settings = [
             [
@@ -129,30 +131,30 @@ class ImportManagerTest extends TestAbstract
             // Report classroom1 override
             [
                 $statsReport,
-                $statsReport->quarter->classroom1Date,
+                $statsReport->quarter->getClassroom1Date(),
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom1Date->toDateString() . " 7:00:59pm", $timezone),
+                Carbon::parse($statsReport->quarter->getClassroom1Date()->toDateString() . " 7:00:59pm", $timezone),
             ],
             // Report classroom2 override
             [
                 $statsReport,
-                $statsReport->quarter->classroom2Date,
+                $statsReport->quarter->getClassroom2Date(),
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom2Date->toDateString() . " 11:59:59pm", $timezone),
+                Carbon::parse($statsReport->quarter->getClassroom2Date()->toDateString() . " 11:59:59pm", $timezone),
             ],
             // Report classroom3 override
             [
                 $statsReport,
-                $statsReport->quarter->classroom3Date,
+                $statsReport->quarter->getClassroom3Date(),
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom3Date->toDateString() . " 7:00:59pm", $timezone),
+                Carbon::parse($statsReport->quarter->getClassroom3Date()->toDateString() . " 7:00:59pm", $timezone),
             ],
             // Report weekend completion override
             [
                 $statsReport,
-                $statsReport->quarter->endWeekendDate,
+                $statsReport->quarter->getQuarterEndDate(),
                 $settings,
-                Carbon::parse($statsReport->quarter->endWeekendDate->toDateString() . " 5:00:59pm", 'America/Chicago'),
+                Carbon::parse($statsReport->quarter->getQuarterEndDate()->toDateString() . " 5:00:59pm", 'America/Chicago'),
             ],
             // Report specific reportingDate override
             [
@@ -191,12 +193,13 @@ class ImportManagerTest extends TestAbstract
         $statsReport->center->id       = 0;
         $statsReport->center->timezone = $timezone;
 
-        $statsReport->quarter                   = new stdClass;
-        $statsReport->quarter->startWeekendDate = Carbon::create(2015, 11, 20)->startOfDay();
-        $statsReport->quarter->classroom1Date   = Carbon::create(2015, 12, 4)->startOfDay();
-        $statsReport->quarter->classroom2Date   = Carbon::create(2016, 1, 8)->startOfDay();
-        $statsReport->quarter->classroom3Date   = Carbon::create(2016, 2, 5)->startOfDay();
-        $statsReport->quarter->endWeekendDate   = Carbon::create(2016, 2, 19)->startOfDay();
+        $statsReport->quarter          = $this->getQuarterMock([], [
+            'startWeekendDate' => Carbon::create(2015, 11, 20)->startOfDay(),
+            'classroom1Date'   => Carbon::create(2015, 12, 4)->startOfDay(),
+            'classroom2Date'   => Carbon::create(2016, 1, 8)->startOfDay(),
+            'classroom3Date'   => Carbon::create(2016, 2, 5)->startOfDay(),
+            'endWeekendDate'   => Carbon::create(2016, 2, 19)->startOfDay(),
+        ]);
 
         $settings = [
             [
@@ -231,39 +234,35 @@ class ImportManagerTest extends TestAbstract
                 $statsReport,
                 Carbon::create(2015, 11, 27)->startOfDay(),
                 [],
-                Carbon::create(2015, 11, 28, 10, 0, 59, $timezone),
+                Carbon::create(2015, 11, 28, 10, 0, 0, $timezone),
             ],
             // Report classroom1 override next day
             [
                 $statsReport,
-                $statsReport->quarter->classroom1Date,
+                $statsReport->quarter->getClassroom1Date(),
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom1Date->copy()
-                                                                   ->addDay()
-                                                                   ->toDateString() . " 10:00:00am", $timezone),
+                Carbon::create(2015, 12, 5, 10, 0, 0, $timezone),
             ],
             // Report classroom2 override next day
             [
                 $statsReport,
-                $statsReport->quarter->classroom2Date,
+                $statsReport->quarter->getClassroom2Date(),
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom2Date->copy()
-                                                                   ->addDay()
-                                                                   ->toDateString() . " 12:00:00pm", $timezone),
+                Carbon::create(2016, 1, 9, 12, 0, 0, $timezone),
             ],
             // Report classroom3 override same day
             [
                 $statsReport,
-                $statsReport->quarter->classroom3Date,
+                $statsReport->quarter->getClassroom3Date(),
                 $settings,
-                Carbon::parse($statsReport->quarter->classroom3Date->toDateString() . " 9:00:00pm", $timezone),
+                Carbon::create(2016, 2, 5, 21, 0, 0, $timezone),
             ],
             // Report specific reportingDate specific response date
             [
                 $statsReport,
                 Carbon::create(2016, 1, 1)->startOfDay(),
                 $settings,
-                Carbon::create(2015, 12, 31, 21, 0, 00, $timezone),
+                Carbon::create(2015, 12, 31, 21, 0, 0, $timezone),
             ],
         ];
     }

--- a/src/tests/unit/Traits/MocksQuarters.php
+++ b/src/tests/unit/Traits/MocksQuarters.php
@@ -1,0 +1,95 @@
+<?php
+namespace TmlpStats\Tests\Traits;
+
+use TmlpStats\Quarter;
+
+trait MocksQuarters
+{
+    protected function getQuarterMock($methods = [], $constructorArgs = [])
+    {
+        $defaultMethods = [
+            'getFirstWeekDate',
+            'getQuarterStartDate',
+            'getQuarterEndDate',
+            'getClassroom1Date',
+            'getClassroom2Date',
+            'getClassroom3Date',
+            'getQuarterDate',
+        ];
+        $methods = $this->mergeMockMethods($defaultMethods, $methods);
+
+        $quarter = $this->getMockBuilder(Quarter::class)
+                        ->setMethods($methods)
+                        ->getMock();
+
+        if (!$constructorArgs) {
+            return $quarter;
+        }
+
+        $startWeekendDate = isset($constructorArgs['startWeekendDate'])
+            ? $constructorArgs['startWeekendDate']
+            : null;
+
+        $endWeekendDate = isset($constructorArgs['endWeekendDate'])
+            ? $constructorArgs['endWeekendDate']
+            : null;
+
+        $classroom1Date = isset($constructorArgs['classroom1Date'])
+            ? $constructorArgs['classroom1Date']
+            : null;
+
+        $classroom2Date = isset($constructorArgs['classroom2Date'])
+            ? $constructorArgs['classroom2Date']
+            : null;
+
+        $classroom3Date = isset($constructorArgs['classroom3Date'])
+            ? $constructorArgs['classroom3Date']
+            : null;
+
+        $firstWeekDate = isset($constructorArgs['firstWeekDate'])
+            ? $constructorArgs['firstWeekDate']
+            : null;
+
+        if (!$firstWeekDate && $startWeekendDate) {
+            $firstWeekDate = $startWeekendDate->copy();
+            $firstWeekDate->addWeek();
+        }
+
+        $quarter->expects($this->any())
+                ->method('getFirstWeekDate')
+                ->will($this->returnValue($firstWeekDate));
+
+        $quarter->expects($this->any())
+                ->method('getQuarterStartDate')
+                ->will($this->returnValue($startWeekendDate));
+
+        $quarter->expects($this->any())
+                ->method('getQuarterEndDate')
+                ->will($this->returnValue($endWeekendDate));
+
+        $quarter->expects($this->any())
+                ->method('getClassroom1Date')
+                ->will($this->returnValue($classroom1Date));
+
+        $quarter->expects($this->any())
+                ->method('getClassroom2Date')
+                ->will($this->returnValue($classroom2Date));
+
+        $quarter->expects($this->any())
+                ->method('getClassroom3Date')
+                ->will($this->returnValue($classroom3Date));
+
+        $quarter->expects($this->any())
+                ->method('getQuarterDate')
+                ->will($this->returnCallback(function() use ($constructorArgs) {
+                    $args = func_get_args();
+                    $this->assertEquals(2, count($args));
+
+                    return isset($constructorArgs[$args[0]])
+                        ? $constructorArgs[$args[0]]
+                        : null;
+                }));
+
+        return $quarter;
+    }
+}

--- a/src/tests/unit/Validate/Objects/ClassListValidatorTest.php
+++ b/src/tests/unit/Validate/Objects/ClassListValidatorTest.php
@@ -2,6 +2,7 @@
 namespace TmlpStats\Tests\Validate\Objects;
 
 use TmlpStats\Tests\Traits\MocksMessages;
+use TmlpStats\Tests\Traits\MocksQuarters;
 use TmlpStats\Tests\Traits\MocksSettings;
 use TmlpStats\Util;
 use TmlpStats\Validate\Objects\ClassListValidator;
@@ -10,7 +11,7 @@ use stdClass;
 
 class ClassListValidatorTest extends ObjectsValidatorTestAbstract
 {
-    use MocksSettings, MocksMessages;
+    use MocksSettings, MocksMessages, MocksQuarters;
 
     protected $testClass = ClassListValidator::class;
 
@@ -1072,31 +1073,32 @@ class ClassListValidatorTest extends ObjectsValidatorTestAbstract
     public function providerValidateTravel()
     {
         $statsReport          = new stdClass;
-        $statsReport->quarter = new stdClass;
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'classroom2Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+            'endWeekendDate' => Carbon::createFromDate(2015, 5, 29)->startOfDay(),
+        ]);
         $statsReport->center  = null;
 
-        $statsReport->reportingDate           = Carbon::createFromDate(2015, 3, 13);
-        $statsReport->quarter->classroom2Date = Carbon::createFromDate(2015, 4, 17);
-        $statsReport->quarter->endWeekendDate = Carbon::createFromDate(2015, 5, 29);
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 3, 13)->startOfDay();
 
         $statsReportOnClassroom2                = clone $statsReport;
-        $statsReportOnClassroom2->reportingDate = Carbon::createFromDate(2015, 4, 17);
+        $statsReportOnClassroom2->reportingDate = Carbon::createFromDate(2015, 4, 17)->startOfDay();
 
         $statsReportAfterClassroom2                = clone $statsReport;
-        $statsReportAfterClassroom2->reportingDate = Carbon::createFromDate(2015, 4, 24);
+        $statsReportAfterClassroom2->reportingDate = Carbon::createFromDate(2015, 4, 24)->startOfDay();
 
         $statsReportLast2Weeks                = clone $statsReport;
-        $statsReportLast2Weeks->reportingDate = Carbon::createFromDate(2015, 5, 15);
+        $statsReportLast2Weeks->reportingDate = Carbon::createFromDate(2015, 5, 15)->startOfDay();
 
-        $statsReportWithClassroom1                          = clone $statsReport;
-        $statsReportWithClassroom1->quarter                 = clone $statsReport->quarter;
-        $statsReportWithClassroom1->quarter->classroom2Date = null;
-        $statsReportWithClassroom1->quarter->classroom1Date = $statsReport->quarter->classroom2Date;
+        $statsReportWithClassroom1          = clone $statsReport;
+        $statsReportWithClassroom1->quarter = $this->getQuarterMock([], [
+            'classroom1Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+        ]);
 
-        $statsReportWithClassroom3                          = clone $statsReport;
-        $statsReportWithClassroom3->quarter                 = clone $statsReport->quarter;
-        $statsReportWithClassroom3->quarter->classroom2Date = null;
-        $statsReportWithClassroom3->quarter->classroom3Date = $statsReport->quarter->classroom2Date;
+        $statsReportWithClassroom3          = clone $statsReport;
+        $statsReportWithClassroom3->quarter = $this->getQuarterMock([], [
+            'classroom3Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+        ]);
 
         return [
             // Before 2nd Classroom, all null

--- a/src/tests/unit/Validate/Objects/CommCourseInfoValidatorTest.php
+++ b/src/tests/unit/Validate/Objects/CommCourseInfoValidatorTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace TmlpStats\Tests\Validate\Objects;
 
+use TmlpStats\Center;
 use TmlpStats\Tests\Traits\MocksMessages;
+use TmlpStats\Tests\Traits\MocksQuarters;
 use TmlpStats\Util;
 use TmlpStats\Validate\Objects\CommCourseInfoValidator;
 use Illuminate\Support\Facades\Log;
@@ -10,7 +12,7 @@ use stdClass;
 
 class CommCourseInfoValidatorTest extends ObjectsValidatorTestAbstract
 {
-    use MocksMessages;
+    use MocksMessages, MocksQuarters;
 
     protected $testClass = CommCourseInfoValidator::class;
 
@@ -473,9 +475,11 @@ class CommCourseInfoValidatorTest extends ObjectsValidatorTestAbstract
 
     public function providerValidateCourseStartDate()
     {
-        $statsReport                            = new stdClass;
-        $statsReport->quarter                   = new stdClass;
-        $statsReport->quarter->startWeekendDate = Carbon::createFromDate(2015, 2, 20);
+        $statsReport          = new stdClass;
+        $statsReport->center  = new Center();
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'startWeekendDate' => Carbon::createFromDate(2015, 2, 20)->startOfDay(),
+        ]);
 
         return [
             // Gracefully handle null start date (don't blow up - required validator will catch this error)

--- a/src/tests/unit/Validate/Objects/StatsReportValidatorTest.php
+++ b/src/tests/unit/Validate/Objects/StatsReportValidatorTest.php
@@ -3,13 +3,15 @@ namespace TmlpStats\Tests\Validate\Objects;
 
 use Carbon\Carbon;
 use stdClass;
+use TmlpStats\Center;
 use TmlpStats\Tests\Traits\MocksMessages;
+use TmlpStats\Tests\Traits\MocksQuarters;
 use TmlpStats\Tests\Validate\ValidatorTestAbstract;
 use TmlpStats\Validate\Objects\StatsReportValidator;
 
 class StatsReportValidatorTest extends ValidatorTestAbstract
 {
-    use MocksMessages;
+    use MocksMessages, MocksQuarters;
 
     protected $testClass = StatsReportValidator::class;
 
@@ -32,20 +34,21 @@ class StatsReportValidatorTest extends ValidatorTestAbstract
     public function providerValidate()
     {
         $statsReport                = new stdClass;
-        $statsReport->reportingDate = Carbon::createFromDate(2015, 12, 18);
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 12, 18)->startOfDay();
 
-        $statsReport->quarter                 = new stdClass;
-        $statsReport->quarter->endWeekendDate = Carbon::createFromDate(2016, 02, 19);
+        $statsReport->quarter       = $this->getQuarterMock([], [
+            'endWeekendDate' => Carbon::createFromDate(2016, 2, 19)->startOfDay(),
+        ]);
 
-        $statsReport->center               = new stdClass;
+        $statsReport->center               = new Center();
         $statsReport->center->sheetVersion = '15.4.2';
 
         $statsReportLastWeek                = clone $statsReport;
-        $statsReportLastWeek->reportingDate = Carbon::createFromDate(2016, 02, 17);
+        $statsReportLastWeek->reportingDate = Carbon::createFromDate(2016, 2, 17)->startOfDay();
 
 
         $statsReportCorrectLastWeek                = clone $statsReport;
-        $statsReportCorrectLastWeek->reportingDate = Carbon::createFromDate(2016, 02, 19);
+        $statsReportCorrectLastWeek->reportingDate = Carbon::createFromDate(2016, 2, 19)->startOfDay();
 
         return [
             // Success Case
@@ -124,7 +127,7 @@ class StatsReportValidatorTest extends ValidatorTestAbstract
             [
                 [
                     'expectedVersion' => '15.4.2',
-                    'expectedDate'    => $statsReportLastWeek->quarter->endWeekendDate,
+                    'expectedDate'    => $statsReportLastWeek->quarter->getQuarterEndDate(),
                 ],
                 $statsReportLastWeek,
                 [
@@ -136,7 +139,7 @@ class StatsReportValidatorTest extends ValidatorTestAbstract
             [
                 [
                     'expectedVersion' => '15.4.2',
-                    'expectedDate'    => $statsReportCorrectLastWeek->quarter->endWeekendDate,
+                    'expectedDate'    => $statsReportCorrectLastWeek->quarter->getQuarterEndDate(),
                 ],
                 $statsReportCorrectLastWeek,
                 [],

--- a/src/tests/unit/Validate/Objects/TmlpRegistrationValidatorTest.php
+++ b/src/tests/unit/Validate/Objects/TmlpRegistrationValidatorTest.php
@@ -1,8 +1,9 @@
 <?php
 namespace TmlpStats\Tests\Validate\Objects;
 
-use TmlpStats\ModelCache;
+use TmlpStats\Center;
 use TmlpStats\Tests\Traits\MocksMessages;
+use TmlpStats\Tests\Traits\MocksQuarters;
 use TmlpStats\Tests\Traits\MocksSettings;
 use TmlpStats\Util;
 use TmlpStats\Validate\Objects\TmlpRegistrationValidator;
@@ -12,7 +13,7 @@ use stdClass;
 
 class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
 {
-    use MocksSettings, MocksMessages;
+    use MocksSettings, MocksMessages, MocksQuarters;
 
     protected $testClass = TmlpRegistrationValidator::class;
 
@@ -685,7 +686,7 @@ class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
                     'aft'              => null,
                 ]),
                 [],
-                true
+                true,
             ],
             // validateWeekendReg Passes bef with team 1
             [
@@ -696,7 +697,7 @@ class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
                     'aft'              => null,
                 ]),
                 [],
-                true
+                true,
             ],
             // validateWeekendReg Passes dur
             [
@@ -707,7 +708,7 @@ class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
                     'aft'              => null,
                 ]),
                 [],
-                true
+                true,
             ],
             // validateWeekendReg Passes aft
             [
@@ -718,7 +719,7 @@ class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
                     'aft'              => 2,
                 ]),
                 [],
-                true
+                true,
             ],
             // validateWeekendReg Fails When Both Bef And Dur Set
             [
@@ -1301,10 +1302,12 @@ class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
     public function providerValidateDates()
     {
         $statsReport          = new stdClass;
-        $statsReport->quarter = new stdClass;
+        $statsReport->center  = new Center();
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'startWeekendDate' => Carbon::createFromDate(2014, 11, 14)->startOfDay(),
+        ]);
 
-        $statsReport->reportingDate             = Carbon::createFromDate(2015, 1, 21);
-        $statsReport->quarter->startWeekendDate = Carbon::createFromDate(2014, 11, 14);
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 1, 21);
 
         return [
             // Withdraw date OK
@@ -2199,11 +2202,12 @@ class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
     public function providerValidateTravelPasses()
     {
         $statsReport          = new stdClass;
-        $statsReport->quarter = new stdClass;
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'classroom2Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+        ]);
         $statsReport->center  = null;
 
-        $statsReport->reportingDate           = Carbon::createFromDate(2015, 5, 8);
-        $statsReport->quarter->classroom2Date = Carbon::createFromDate(2015, 4, 17);
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 5, 8);
 
         return [
             // validateTravel Passes When Before Second Classroom
@@ -2301,12 +2305,13 @@ class TmlpRegistrationValidatorTest extends ObjectsValidatorTestAbstract
     public function providerValidateTravelFails()
     {
         $statsReport          = new stdClass;
-        $statsReport->quarter = new stdClass;
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'classroom2Date' => Carbon::createFromDate(2015, 4, 17)->startOfDay(),
+            'endWeekendDate' => Carbon::createFromDate(2015, 5, 29)->startOfDay(),
+        ]);
         $statsReport->center  = null;
 
-        $statsReport->reportingDate           = Carbon::createFromDate(2015, 5, 8);
-        $statsReport->quarter->classroom2Date = Carbon::createFromDate(2015, 4, 17);
-        $statsReport->quarter->endWeekendDate = Carbon::createFromDate(2015, 5, 29);
+        $statsReport->reportingDate = Carbon::createFromDate(2015, 5, 8);
 
         $statsReportLastTwoWeeks                = clone $statsReport;
         $statsReportLastTwoWeeks->reportingDate = Carbon::createFromDate(2015, 5, 15);

--- a/src/tests/unit/Validate/Relationships/TeamExpansionValidatorTest.php
+++ b/src/tests/unit/Validate/Relationships/TeamExpansionValidatorTest.php
@@ -3,6 +3,8 @@ namespace TmlpStats\Tests\Validate\Relationships;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Log;
+use TmlpStats\Center;
+use TmlpStats\Tests\Traits\MocksQuarters;
 use TmlpStats\Tests\Validate\ValidatorTestAbstract;
 use TmlpStats\Validate\Relationships\TeamExpansionValidator;
 
@@ -10,6 +12,8 @@ use stdClass;
 
 class TeamExpansionValidatorTest extends ValidatorTestAbstract
 {
+    use MocksQuarters;
+
     protected $testClass = TeamExpansionValidator::class;
 
     /**
@@ -46,9 +50,11 @@ class TeamExpansionValidatorTest extends ValidatorTestAbstract
 
     public function providerValidate()
     {
-        $statsReport                            = new stdClass;
-        $statsReport->quarter                   = new stdClass;
-        $statsReport->quarter->startWeekendDate = Carbon::createFromDate(2015, 5, 29)->startOfDay();
+        $statsReport          = new stdClass;
+        $statsReport->center  = new Center();
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'startWeekendDate' => Carbon::createFromDate(2015, 5, 29)->startOfDay(),
+        ]);
 
         $statsReport->reportingDate = Carbon::createFromDate(2015, 6, 5)->startOfDay();
 

--- a/src/tests/unit/Validate/ValidatorAbstractTest.php
+++ b/src/tests/unit/Validate/ValidatorAbstractTest.php
@@ -3,6 +3,7 @@ namespace TmlpStats\Tests\Validate;
 
 use Carbon\Carbon;
 use stdClass;
+use TmlpStats\Tests\Traits\MocksQuarters;
 
 class ValidatorAbstractImplementation extends \TmlpStats\Validate\ValidatorAbstract
 {
@@ -21,6 +22,8 @@ class ValidatorAbstractImplementation extends \TmlpStats\Validate\ValidatorAbstr
 
 class ValidatorAbstractTest extends ValidatorTestAbstract
 {
+    use MocksQuarters;
+
     protected $testClass = ValidatorAbstractImplementation::class;
 
     protected $dataFields = [];
@@ -31,8 +34,9 @@ class ValidatorAbstractTest extends ValidatorTestAbstract
         $statsReport->center = new stdClass;
         $statsReport->center->name = 'Vancouver';
 
-        $statsReport->quarter = new stdClass;
-        $statsReport->quarter->startWeekendDate = Carbon::create(2015, 11, 20);
+        $statsReport->quarter = $this->getQuarterMock([], [
+            'startWeekendDate' => Carbon::createFromDate(2015, 11, 20)->startOfDay(),
+        ]);
 
         $statsReport->reportingDate = Carbon::create(2015, 12, 18);
 


### PR DESCRIPTION
Some centers have different classroom dates than the rest of the region (especially important for classroom 2). Make quarter dates configurable by center