### PR TITLE
Only email this quarter's accountables

### DIFF
--- a/src/app/Import/ImportManager.php
+++ b/src/app/Import/ImportManager.php
@@ -275,6 +275,20 @@ class ImportManager
             ? $emailMap['center']
             : $emailMap['statistician'];
 
+        // If this is the first week and the report didn't validate, we also didn't import any of the
+        // new accountables. Don't send the email to last quarters accountables, and instead just send it to the
+        // center's stats email.
+        $accountablesCopied = true;
+        if ($statsReport->quarter->isFirstWeek() && !$statsReport->isValidated()) {
+            unset($emailMap['programManager']);
+            unset($emailMap['classroomLeader']);
+            unset($emailMap['t1TeamLeader']);
+            unset($emailMap['t2TeamLeader']);
+            unset($emailMap['statistician']);
+            unset($emailMap['statisticianApprentice']);
+            $accountablesCopied = false;
+        }
+
         $mailingList = Setting::name('centerReportMailingList')
                               ->with($center, $quarter)
                               ->get();
@@ -315,7 +329,7 @@ class ImportManager
         $reportingDate = $statsReport->reportingDate;
         try {
             Mail::send('emails.statssubmitted',
-                compact('user', 'centerName', 'submittedAt', 'sheet', 'isLate', 'due', 'comment', 'respondByDateTime', 'reportUrl', 'reportingDate'),
+                compact('user', 'centerName', 'submittedAt', 'sheet', 'isLate', 'due', 'comment', 'respondByDateTime', 'reportUrl', 'reportingDate', 'accountablesCopied'),
                 function ($message) use ($emails, $emailMap, $centerName, $sheetPath, $sheetName) {
                     // Only send email to centers in production
                     if (env('APP_ENV') === 'prod') {

--- a/src/resources/views/emails/statssubmitted.blade.php
+++ b/src/resources/views/emails/statssubmitted.blade.php
@@ -14,6 +14,11 @@ We received them on {{ $submittedAt->format('l, F jS \a\t g:ia') }} your local t
     <br/>
 @endif
 
+@if (!$accountablesCopied)
+    Since your sheet did not pass validation, we weren't able to determine who else to include when sending this email. Please reply-all and add any missing accountables to the email chain.<br/>
+    <br/>
+@endif
+
 You are not complete yet. Your regional statistician will review your sheet and declare you complete by {{ $respondByDateTime->format('l \a\t g:ia') }} your local time.<br/>
 <br/>
 


### PR DESCRIPTION
If a statistician submits their sheet in the first week and it didn't pass validation, we won't have the accurate list of accountables for the new quarter The end result is we send the report to all of last quarter's accountables.

In this case, only send the email to the center's stats email, and request they manually copy the relevant accountables.

fixes issue #321 